### PR TITLE
Disables (hides) mint button when it cannot be used

### DIFF
--- a/src/components/topbar/topbar/topbar-global.tsx
+++ b/src/components/topbar/topbar/topbar-global.tsx
@@ -106,13 +106,10 @@ const TopbarGlobal: FC<TopbarProps> = ({ name: _domain }) => {
     if (account) {
       mintNFTEnabled = (account.toLowerCase() == name.value.owner.id.toLowerCase());
     }
-    
   } catch (e) {
     console.log(`mintNFTEnabled error: ${e}`);
   }
-  
 
-  console.log(name.value, mintNFTEnabled, account);
 
   return (
     <div

--- a/src/components/topbar/topbar/topbar-global.tsx
+++ b/src/components/topbar/topbar/topbar-global.tsx
@@ -28,7 +28,7 @@ var lastY = 0 // Just a global variable to stash last scroll position
 
 const TopbarGlobal: FC<TopbarProps> = ({ name: _domain }) => {
   const context = useWeb3React<Web3Provider>();
-  const { active, connector, error } = context;
+  const { active, connector, error, account } = context;
   const { useDomain } = useDomainCache();
   const domainContext = useDomain(_domain);
   const { name } = domainContext;
@@ -101,6 +101,19 @@ const TopbarGlobal: FC<TopbarProps> = ({ name: _domain }) => {
 
   if (name.isNothing()) return null;
 
+  let mintNFTEnabled = false;
+  try {
+    if (account) {
+      mintNFTEnabled = (account.toLowerCase() == name.value.owner.id.toLowerCase());
+    }
+    
+  } catch (e) {
+    console.log(`mintNFTEnabled error: ${e}`);
+  }
+  
+
+  console.log(name.value, mintNFTEnabled, account);
+
   return (
     <div
       className={`topbarContainerNeo`}
@@ -128,9 +141,10 @@ const TopbarGlobal: FC<TopbarProps> = ({ name: _domain }) => {
               <FutureButton glow onClick={showWallet}>Connect Wallet</FutureButton>
             ) : (
               <>
+                {mintNFTEnabled ? 
                 <FutureButton glow onClick={showMint}>
                   Mint New NFT
-                </FutureButton>
+                </FutureButton> : null }
                 <div onClick={openProfile} className="profile-btn">
                   <div className="profile-btn">
                     <Profile

--- a/src/lib/useDomainStore.ts
+++ b/src/lib/useDomainStore.ts
@@ -57,7 +57,9 @@ export const DOMAIN_QUERY = gql`
         id
         name
       }
-      owner
+      owner {
+        id
+      }
       minter
       lockedBy
       isLocked


### PR DESCRIPTION
Added code to hide the mint button when a user wouldn't be able to mint a domain from their current page.

Ideally the button would just be greyed out but there is no ability to 'disable' a 'FutureButton' right now.