### PR TITLE
Numbers to locale strings

### DIFF
--- a/src/components/Tables/DomainTable/HighestBid.tsx
+++ b/src/components/Tables/DomainTable/HighestBid.tsx
@@ -63,7 +63,7 @@ const HighestBid: React.FC<HighestBidProps> = ({ domain, refreshKey }) => {
 	} else if (highestBid === 0) {
 		displayElement = <>-</>;
 	} else if (highestBid && highestBid > 0) {
-		displayElement = <>{highestBid} WILD</>;
+		displayElement = <>{highestBid.toLocaleString()} WILD</>;
 	}
 
 	return <>{displayElement}</>;

--- a/src/components/Tables/DomainTable/NumBids.tsx
+++ b/src/components/Tables/DomainTable/NumBids.tsx
@@ -57,7 +57,7 @@ const NumBids: React.FC<NumBidsProps> = ({ domain, refreshKey }) => {
 	} else if (didApiCallFail) {
 		displayElement = <>Failed to retrieve</>;
 	} else {
-		displayElement = <>{numBids || 0}</>;
+		displayElement = <>{numBids?.toLocaleString() || 0}</>;
 	}
 
 	return <>{displayElement}</>;

--- a/src/containers/NFTView/NFTView.tsx
+++ b/src/containers/NFTView/NFTView.tsx
@@ -243,8 +243,7 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 						account.length - 4,
 					)}`}</a>
 				</b>{' '}
-				made an offer of{' '}
-				<b>{Number(amount.toFixed(2)).toLocaleString()} WILD</b>
+				made an offer of <b>{Number(amount).toLocaleString()} WILD</b>
 			</div>
 			<div>
 				<b>{moment(date).fromNow()}</b>


### PR DESCRIPTION
Got given some feedback that some numbers weren't formatted to the user's locale, i.e. 1000.00 as 1,000.00, or 1.000,00, etc. I had a scan over all the places we're rendering numbers, and it looks like `NumBids.tsx` and `HighestBid.tsx` were the only places not converting to a locale string.

Also removed a line where a WILD value was being rounded to 2dp (history items in `NFTView.tsx`).