### PR TITLE
Fixes for problems that arise when switching/disconnecting wallets

### DIFF
--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -51,6 +51,12 @@ const Profile: React.FC<ProfileProps> = ({ id, yours, onNavigate }) => {
 	// Effects //
 	/////////////
 
+	////////////
+	// Render //
+	////////////
+
+	if (!id) return <></>; // if user has disconnected wallet while profile is open
+
 	return (
 		<div
 			className={`${ProfileStyle.profile} blur border-primary border-rounded`}

--- a/src/components/Tables/DomainTable/DomainTable.tsx
+++ b/src/components/Tables/DomainTable/DomainTable.tsx
@@ -147,6 +147,13 @@ const DomainTable: React.FC<DomainTableProps> = ({
 		};
 	}, []);
 
+	useEffect(() => {
+		if (!userId) {
+			setBiddingOn(undefined);
+			closeModal();
+		}
+	}, [userId]);
+
 	// Resizes the table container
 	// (The animation is done in CSS)
 	useEffect(() => {
@@ -266,12 +273,21 @@ const DomainTable: React.FC<DomainTableProps> = ({
 	// React Fragments //
 	/////////////////////
 
-	const overlays = () => (
-		<Overlay onClose={closeModal} centered open={modal === Modals.Bid}>
-			<MakeABid domain={biddingOn!} onBid={onBid} />
-		</Overlay>
-	);
-
+	const overlays = () => {
+		return (
+			<>
+				{userId && (
+					<Overlay
+						onClose={closeModal}
+						centered
+						open={modal === Modals.Bid && biddingOn !== undefined}
+					>
+						<MakeABid domain={biddingOn!} onBid={onBid} />
+					</Overlay>
+				)}
+			</>
+		);
+	};
 	////////////
 	// Render //
 	////////////

--- a/src/components/Tables/DomainTable/DomainTable.tsx
+++ b/src/components/Tables/DomainTable/DomainTable.tsx
@@ -33,6 +33,7 @@ import { useRefreshToken } from 'lib/hooks/useRefreshToken';
 // TODO: Need some proper type definitions for an array of domains
 type DomainTableProps = {
 	className?: string;
+	disableButton?: boolean;
 	domains: Domain[];
 	empty?: boolean;
 	hideOwnBids?: boolean;
@@ -55,6 +56,7 @@ enum Modals {
 
 const DomainTable: React.FC<DomainTableProps> = ({
 	className,
+	disableButton,
 	domains,
 	empty,
 	hideOwnBids,
@@ -107,6 +109,7 @@ const DomainTable: React.FC<DomainTableProps> = ({
 	};
 
 	const buttonClick = (domain: Domain) => {
+		if (disableButton) return;
 		// Default behaviour
 		try {
 			if (domain?.owner.id.toLowerCase() !== userId?.toLowerCase()) {
@@ -221,7 +224,7 @@ const DomainTable: React.FC<DomainTableProps> = ({
 							{!rowButtonText && (
 								<FutureButton
 									style={{ marginLeft: 'auto', textTransform: 'uppercase' }}
-									glow={shouldGlow}
+									glow={disableButton === false && shouldGlow}
 									onClick={() => buttonClick(domain)}
 								>
 									{rowButtonText || 'Make A Bid'}

--- a/src/containers/MakeABid/MakeABid.tsx
+++ b/src/containers/MakeABid/MakeABid.tsx
@@ -423,53 +423,62 @@ const MakeABid: React.FC<MakeABidProps> = ({ domain, onBid }) => {
 					{details()}
 				</div>
 				<div className={styles.InputWrapper}>
-					{loadingWildBalance && (
+					{domain.owner.id.toLowerCase() === account?.toLowerCase() && (
+						<p className={styles.Error} style={{ paddingTop: '16px' }}>
+							You can not bid on your own domain
+						</p>
+					)}
+					{domain.owner.id.toLowerCase() !== account?.toLowerCase() && (
 						<>
-							<LoadingIndicator text="Checking WILD Balance" />
+							{loadingWildBalance && (
+								<>
+									<LoadingIndicator text="Checking WILD Balance" />
+								</>
+							)}
+							{
+								<>
+									<p className="glow-text-blue">
+										Enter the amount you wish to bid:
+									</p>
+									<span style={{ marginBottom: 8 }} className={styles.Estimate}>
+										Your Balance: {Number(wildBalance).toLocaleString()} WILD
+									</span>
+									<form onSubmit={formSubmit}>
+										<TextInput
+											onChange={(text: string) => setBid(text)}
+											placeholder="Bid amount (WILD)"
+											error={error.length > 0}
+											errorText={error}
+											numeric
+											text={bid}
+											style={{ width: 268, margin: '0 auto' }}
+										/>
+									</form>
+									{estimation()}
+									{bidTooHighWarning}
+									<FutureButton
+										style={{
+											height: 36,
+											borderRadius: 18,
+											textTransform: 'uppercase',
+											margin: '32px auto 0 auto',
+										}}
+										loading={isBidPending}
+										onClick={() => {
+											if (!isBidValid) {
+												return;
+											}
+
+											continueBid();
+										}}
+										glow={isBidValid}
+									>
+										Continue
+									</FutureButton>
+								</>
+							}
 						</>
 					)}
-					{
-						<>
-							<p className="glow-text-blue">
-								Enter the amount you wish to bid:
-							</p>
-							<span style={{ marginBottom: 8 }} className={styles.Estimate}>
-								Your Balance: {Number(wildBalance).toLocaleString()} WILD
-							</span>
-							<form onSubmit={formSubmit}>
-								<TextInput
-									onChange={(text: string) => setBid(text)}
-									placeholder="Bid amount (WILD)"
-									error={error.length > 0}
-									errorText={error}
-									numeric
-									text={bid}
-									style={{ width: 268, margin: '0 auto' }}
-								/>
-							</form>
-							{estimation()}
-							{bidTooHighWarning}
-							<FutureButton
-								style={{
-									height: 36,
-									borderRadius: 18,
-									textTransform: 'uppercase',
-									margin: '32px auto 0 auto',
-								}}
-								loading={isBidPending}
-								onClick={() => {
-									if (!isBidValid) {
-										return;
-									}
-
-									continueBid();
-								}}
-								glow={isBidValid}
-							>
-								Continue
-							</FutureButton>
-						</>
-					}
 				</div>
 			</>
 		);

--- a/src/containers/MakeABid/MakeABid.tsx
+++ b/src/containers/MakeABid/MakeABid.tsx
@@ -81,7 +81,7 @@ const MakeABid: React.FC<MakeABidProps> = ({ domain, onBid }) => {
 
 	//- Web3 Wallet Data
 	const walletContext = useWeb3React<Web3Provider>();
-	const { account } = walletContext;
+	const { account, active } = walletContext;
 
 	const znsContracts = useZnsContracts()!;
 	const zAuctionAddress = znsContracts.zAuction.address;
@@ -299,6 +299,8 @@ const MakeABid: React.FC<MakeABidProps> = ({ domain, onBid }) => {
 	/////////////////////
 	// React Fragments //
 	/////////////////////
+
+	if (!active) return <></>; // Render nothing if wallet disconnected
 
 	const modals = () => (
 		<>

--- a/src/containers/NFTView/NFTView.tsx
+++ b/src/containers/NFTView/NFTView.tsx
@@ -69,7 +69,7 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 
 	//- Web3 Wallet Data
 	const walletContext = useWeb3React<Web3Provider>();
-	const { account, chainId } = walletContext;
+	const { account, active, chainId } = walletContext;
 
 	const networkType = chainIdToNetworkType(chainId);
 	const contracts = useZnsContracts();
@@ -262,7 +262,7 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 				Transfer Ownership
 			</FutureButton>
 			<FutureButton
-				glow={!isOwnedByYou}
+				glow={!isOwnedByYou && active}
 				onClick={openBidOverlay}
 				style={{ height: 36, borderRadius: 18 }}
 			>

--- a/src/pages/ZNS/ZNS.tsx
+++ b/src/pages/ZNS/ZNS.tsx
@@ -257,6 +257,15 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 		}
 		if (triedEagerConnect)
 			addNotification(active ? 'Wallet connected.' : 'Wallet disconnected.');
+
+		// Check if we need to close a modal
+		if (
+			(!active && modal === Modal.Profile) ||
+			modal === Modal.Transfer ||
+			modal === Modal.Mint
+		) {
+			closeModal();
+		}
 	}, [active]);
 
 	useEffect(() => {

--- a/src/pages/ZNS/ZNS.tsx
+++ b/src/pages/ZNS/ZNS.tsx
@@ -294,7 +294,7 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 							creatorId={znsDomain?.domain?.minter?.id || ''}
 							disabled={
 								znsDomain.domain?.owner?.id.toLowerCase() ===
-								account?.toLowerCase()
+									account?.toLowerCase() || !active
 							}
 							ownerId={znsDomain?.domain?.owner?.id || ''}
 							mvpVersion={mvpVersion}
@@ -352,6 +352,7 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 					isRootDomain={isRoot}
 					style={{ marginTop: 16 }}
 					empty={(znsDomain.domain && tableData.length === 0) as boolean}
+					disableButton={!active}
 					isGridView={isGridView}
 					setIsGridView={setIsGridView}
 					userId={account as string}


### PR DESCRIPTION
**Problem 1**
Problem: Used to be able to bid on your own domains by opening the bid modal with a different wallet connected, then switch to your main wallet.
Solution: Flow already resets on wallet change - added a check on the first step of the flow to disable the input/continue button when `connected wallet ID === domain owner ID`.

**Problem 2**
Problem: Should not be able to have bid or profile modals open without a wallet connected. With modals open, disconnecting wallet would not close them, which could lead to some functionality crashing.
Solution: Added checks for connected account - if not connected close the bid or profile modal (if open). Also made the bid and profile modals render blank if no `userId` is supplied - not sure if this is the greatest solution.

**Problem 3**
Problem: 'Make A Bid' button should be disabled when no wallet is connected.
Solution: Disabled 'Make A Bid' when no wallet is connected