### PR TITLE
Add missing view/accept bid flow to owned domains table

### DIFF
--- a/src/components/Tables/DomainTable/DomainTable.tsx
+++ b/src/components/Tables/DomainTable/DomainTable.tsx
@@ -16,6 +16,7 @@ import { MakeABid } from 'containers';
 import HighestBid from './components/HighestBid';
 import NumBids from './components/NumBids';
 import NFTCardActions from './components/NFTCardActions';
+import ViewBids from './components/ViewBids';
 
 //- Library Imports
 import 'lib/react-table-config.d.ts';
@@ -115,7 +116,10 @@ const DomainTable: React.FC<DomainTableProps> = ({
 		if (disableButton) return;
 		// Default behaviour
 		try {
-			if (domain?.owner.id.toLowerCase() !== userId?.toLowerCase()) {
+			if (
+				isGlobalTable &&
+				domain?.owner.id.toLowerCase() !== userId?.toLowerCase()
+			) {
 				if (!isMounted.current) return;
 				setBiddingOn(domain);
 				openBidModal();
@@ -170,7 +174,7 @@ const DomainTable: React.FC<DomainTableProps> = ({
 
 	useEffect(() => {
 		checkHeight();
-	}, [containerRef.current?.offsetHeight, searchQuery]);
+	}, [containerRef.current?.offsetHeight, searchQuery, isGridView]);
 
 	/////////////////
 	// React Table //
@@ -225,14 +229,21 @@ const DomainTable: React.FC<DomainTableProps> = ({
 
 					return (
 						<>
-							{!rowButtonText && (
+							{isGlobalTable && (
 								<FutureButton
 									style={{ marginLeft: 'auto', textTransform: 'uppercase' }}
 									glow={disableButton === false && shouldGlow}
 									onClick={() => buttonClick(domain)}
 								>
-									{rowButtonText || 'Make A Bid'}
+									Make A Bid
 								</FutureButton>
+							)}
+							{!isGlobalTable && onRowButtonClick && (
+								<ViewBids
+									style={{ marginLeft: 'auto', textTransform: 'uppercase' }}
+									domain={domain}
+									onClick={onRowButtonClick}
+								/>
 							)}
 						</>
 					);

--- a/src/components/Tables/DomainTable/components/ViewBids.tsx
+++ b/src/components/Tables/DomainTable/components/ViewBids.tsx
@@ -1,0 +1,59 @@
+import { useState, useEffect, useRef } from 'react';
+
+import { useBidProvider } from 'lib/providers/BidProvider';
+
+import { Spinner } from 'components';
+
+import { Bid, Domain, DomainData } from 'lib/types';
+import FutureButton from 'components/Buttons/FutureButton/FutureButton';
+
+type ViewBidsProps = {
+	domain: Domain;
+	onClick: (domain: DomainData) => void;
+	style?: React.CSSProperties;
+};
+
+const ViewBids: React.FC<ViewBidsProps> = ({ domain, onClick, style }) => {
+	let isMounted = useRef(false);
+	const { getBidsForDomain } = useBidProvider();
+	const [bids, setBids] = useState<Bid[] | undefined>();
+
+	const [isLoading, setIsLoading] = useState<boolean>(true);
+
+	const handleClick = () => {
+		if (!isLoading && bids !== undefined) {
+			onClick({
+				domain,
+				bids,
+			});
+		}
+	};
+
+	const getBids = async () => {
+		const bids = await getBidsForDomain(domain);
+		if (!isMounted.current) return;
+		setIsLoading(false);
+		if (bids && bids.length) setBids(bids);
+	};
+
+	useEffect(() => {
+		isMounted.current = true;
+		setIsLoading(true);
+		getBids();
+		return () => {
+			isMounted.current = false;
+		};
+	}, [domain]);
+
+	return (
+		<FutureButton
+			onClick={handleClick}
+			glow={!isLoading && bids !== undefined}
+			style={style}
+		>
+			View Bids
+		</FutureButton>
+	);
+};
+
+export default ViewBids;

--- a/src/components/Tables/DomainTable/components/ViewBids.tsx
+++ b/src/components/Tables/DomainTable/components/ViewBids.tsx
@@ -2,8 +2,6 @@ import { useState, useEffect, useRef } from 'react';
 
 import { useBidProvider } from 'lib/providers/BidProvider';
 
-import { Spinner } from 'components';
-
 import { Bid, Domain, DomainData } from 'lib/types';
 import FutureButton from 'components/Buttons/FutureButton/FutureButton';
 
@@ -15,9 +13,9 @@ type ViewBidsProps = {
 
 const ViewBids: React.FC<ViewBidsProps> = ({ domain, onClick, style }) => {
 	let isMounted = useRef(false);
+
 	const { getBidsForDomain } = useBidProvider();
 	const [bids, setBids] = useState<Bid[] | undefined>();
-
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 
 	const handleClick = () => {


### PR DESCRIPTION
**Problem**
In the process of ironing out the Domain Tables, we dropped the 'View Bids' button from the owned domains table in the Profile modal. This needs to be re-added.

**Solution**
Made a `ViewBids` component, which renders a `FutureButton` with some added validation and API calls. `ViewBids` grabs bid data from API (this will be cached by library that handles this, so it won't add any additional network requirements). If it finds bids, then it makes itself clickable and triggers the passed in click handler. If it finds no bids, then it remains disabled.

![image](https://user-images.githubusercontent.com/12437916/130011231-11289dba-3e00-4581-bd0e-f84af534359d.png)
