### PR TITLE
Request cards show proper currency, rather than defaulting to WILD

### DIFF
--- a/src/components/Tables/RequestTable/components/RequestActions.tsx
+++ b/src/components/Tables/RequestTable/components/RequestActions.tsx
@@ -53,7 +53,7 @@ const RequestActions: React.FC<RequestActionsProps> = ({
 				{Number(
 					ethers.utils.formatEther(request.request.offeredAmount),
 				).toLocaleString()}{' '}
-				WILD
+				{request.contents.stakeCurrency}
 			</span>
 			<span className={styles.Date}>
 				{dateFromTimestamp(request.request.timestamp)}


### PR DESCRIPTION
**Problem**
Request cards (in the grid view of the "Offers" table in Profile) were showing `WILD` by default, but they should say `LOOT`.

**Solution**
I found that there is a `stakeCurrency` string inside the request object, so I just put `stakeCurrency` where `WILD` was and it solved it.

![image](https://user-images.githubusercontent.com/12437916/130012648-a0859eec-707c-4d5c-b897-f89df9223c8f.png)
