### PR TITLE
Better Preview Card animations

### DIFF
--- a/src/components/Cards/PreviewCard/PreviewCard.module.css
+++ b/src/components/Cards/PreviewCard/PreviewCard.module.css
@@ -197,3 +197,12 @@
 .Children {
 	padding: 24.5px 8px 26px 8px;
 }
+
+.Blocker {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	z-index: 5;
+}

--- a/src/components/Cards/PreviewCard/PreviewCard.tsx
+++ b/src/components/Cards/PreviewCard/PreviewCard.tsx
@@ -1,5 +1,5 @@
 //- React imports
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 //- Style Imports
 import styles from './PreviewCard.module.css';
@@ -12,6 +12,7 @@ import { FutureButton, Image, Member, Overlay } from 'components';
 import { Maybe } from 'lib/types';
 
 type PreviewCardProps = {
+	preventInteraction?: boolean;
 	children?: React.ReactNode;
 	creatorId: string;
 	description: string;
@@ -44,6 +45,7 @@ const PreviewCard: React.FC<PreviewCardProps> = ({
 	onMakeBid,
 	onViewDomain,
 	ownerId,
+	preventInteraction,
 	style,
 }) => {
 	//////////////////
@@ -141,6 +143,7 @@ const PreviewCard: React.FC<PreviewCardProps> = ({
 				className={`${styles.PreviewCard} border-primary border-rounded blur`}
 				style={style ? style : {}}
 			>
+				{preventInteraction && <div className={styles.Blocker}></div>}
 				{isLoading && (
 					<div className={styles.Loading}>
 						<div className={styles.Spinner}></div>

--- a/src/components/Cards/PreviewCard/index.tsx
+++ b/src/components/Cards/PreviewCard/index.tsx
@@ -3,7 +3,7 @@
  */
 
 // React Imports
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // Library Imports
 import { Maybe, Metadata } from 'lib/types';
@@ -24,6 +24,7 @@ type PreviewCardContainerProps = {
 	onImageClick?: () => void;
 	ownerId: string;
 	style?: React.CSSProperties;
+	preventInteraction?: boolean;
 	metadataUrl?: string;
 };
 
@@ -37,9 +38,11 @@ const PreviewCardContainer: React.FC<PreviewCardContainerProps> = ({
 	onImageClick,
 	ownerId,
 	style,
+	preventInteraction,
 	metadataUrl,
 }) => {
 	const history = useHistory();
+	const isMounted = useRef<boolean>();
 
 	const [metadata, setMetadata] = useState<Metadata | undefined>();
 	const [isPreviewOpen, setIsPreviewOpen] = useState(false);
@@ -55,10 +58,17 @@ const PreviewCardContainer: React.FC<PreviewCardContainerProps> = ({
 	const closeImagePreview = () => setIsPreviewOpen(false);
 
 	useEffect(() => {
+		isMounted.current = true;
+		return () => {
+			isMounted.current = false;
+		};
+	}, []);
+
+	useEffect(() => {
 		setMetadata(undefined);
-		if (!metadataUrl) return;
+		if (domain === '/' || !metadataUrl) return;
 		getMetadata(metadataUrl).then((m) => {
-			if (!m) return;
+			if (isMounted.current === false || !m) return;
 			else setMetadata(m);
 		});
 	}, [metadataUrl]);
@@ -99,6 +109,7 @@ const PreviewCardContainer: React.FC<PreviewCardContainerProps> = ({
 				onMakeBid={onButtonClick}
 				onViewDomain={onViewDomain}
 				ownerId={ownerId}
+				preventInteraction={preventInteraction}
 				style={style}
 			>
 				{children}

--- a/src/components/Tables/RequestTable/components/RequestActions.tsx
+++ b/src/components/Tables/RequestTable/components/RequestActions.tsx
@@ -53,7 +53,7 @@ const RequestActions: React.FC<RequestActionsProps> = ({
 				{Number(
 					ethers.utils.formatEther(request.request.offeredAmount),
 				).toLocaleString()}{' '}
-				WILD
+				{request.contents.stakeCurrency}
 			</span>
 			<span className={styles.Date}>
 				{dateFromTimestamp(request.request.timestamp)}

--- a/src/pages/ZNS/ZNS.tsx
+++ b/src/pages/ZNS/ZNS.tsx
@@ -279,74 +279,62 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 	// React Fragments //
 	/////////////////////
 
-	const previewCard = () => (
-		<>
-			{/* Preview Card */}
-			{/* TODO: This definitely needs some refactoring */}
-			<Spring
-				from={{ opacity: 0, marginTop: -springAmount }}
-				to={
-					!isRoot && (znsDomain.loading || tableData.length >= 0) && !isNftView
-						? { opacity: 1, marginTop: 0 }
-						: { opacity: 0, marginTop: -springAmount }
-				}
-			>
-				{(styles) => (
-					<animated.div style={styles}>
-						<PreviewCard
-							domain={domain}
-							metadataUrl={znsDomain?.domain?.metadata}
-							creatorId={znsDomain?.domain?.minter?.id || ''}
-							disabled={
-								znsDomain.domain?.owner?.id.toLowerCase() ===
-									account?.toLowerCase() || !active
-							}
-							ownerId={znsDomain?.domain?.owner?.id || ''}
-							mvpVersion={mvpVersion}
-							onButtonClick={openBidOverlay}
-							onImageClick={() => {}}
-						>
-							{mvpVersion === 3 && (
-								<HorizontalScroll fade>
-									<AssetPriceCard
-										title={`${domain.substring(1, 5).toUpperCase()} Price`}
-										price={randomNumber(85, 400, 2)}
-										change={randomNumber(-30, 30, 2)}
-									/>
-									<AssetGraphCard
-										title={`Price ${domain.substring(1, 5).toUpperCase()}`}
-									/>
-									<AssetPriceCard
-										title={`${domain.substring(1, 5).toUpperCase()} Price`}
-										price={randomNumber(85, 400, 2)}
-										change={randomNumber(-30, 30, 2)}
-									/>
-									<AssetMarketCapCard
-										title={`Total ${domain
-											.substring(1, 5)
-											.toUpperCase()} Holders`}
-										price={randomNumber(15000, 40000, 2)}
-									/>
-									<AssetMarketCapCard
-										title={`Total ${domain
-											.substring(1, 5)
-											.toUpperCase()} Holders`}
-										price={randomNumber(15000, 40000, 2)}
-									/>
-									<AssetMarketCapCard
-										title={`Total ${domain
-											.substring(1, 5)
-											.toUpperCase()} Holders`}
-										price={randomNumber(15000, 40000, 2)}
-									/>
-								</HorizontalScroll>
-							)}
-						</PreviewCard>
-					</animated.div>
-				)}
-			</Spring>
-		</>
-	);
+	const previewCard = () => {
+		// if (nftView === true) return <></>;
+
+		const isVisible = domain !== '/' && !isNftView;
+		let to;
+		if (isVisible) {
+			// If should be visible, slide down
+			to = { opacity: 1, marginTop: 0 };
+		} else if (domain === '/') {
+			// If root view, slide up
+			to = { opacity: 0, marginTop: -springAmount };
+		} else {
+			// If NFT view, don't render
+			return <></>;
+		}
+
+		return (
+			<>
+				{/* Preview Card */}
+				{/* TODO: This definitely needs some refactoring */}
+				<Spring to={to}>
+					{(styles) => (
+						<animated.div style={styles}>
+							<PreviewCard
+								domain={domain}
+								metadataUrl={znsDomain?.domain?.metadata}
+								creatorId={znsDomain?.domain?.minter?.id || ''}
+								disabled={
+									znsDomain.domain?.owner?.id.toLowerCase() ===
+										account?.toLowerCase() || !active
+								}
+								ownerId={znsDomain?.domain?.owner?.id || ''}
+								mvpVersion={mvpVersion}
+								onButtonClick={openBidOverlay}
+								onImageClick={() => {}}
+								preventInteraction={domain === '/'}
+							>
+								{mvpVersion === 3 && (
+									<HorizontalScroll fade>
+										<AssetPriceCard
+											title={`${domain.substring(1, 5).toUpperCase()} Price`}
+											price={randomNumber(85, 400, 2)}
+											change={randomNumber(-30, 30, 2)}
+										/>
+										<AssetGraphCard
+											title={`Price ${domain.substring(1, 5).toUpperCase()}`}
+										/>
+									</HorizontalScroll>
+								)}
+							</PreviewCard>
+						</animated.div>
+					)}
+				</Spring>
+			</>
+		);
+	};
 
 	const subdomainTable = () => (
 		<>


### PR DESCRIPTION
**Problems**
- [x] When navigating back to root, the Wilder World logo would show up in the preview card as it animates out
- [x] Could interact with the preview card when it's "hidden"
- [x] Preview Card should disappear and reappear when navigating to NFT view and back, rather than slide up then down.