### PR TITLE
Metamask connecting/reconnecting stuck forever fix

### DIFF
--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -1,5 +1,5 @@
 //- React Imports
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 //- Web3 Imports
 import { Web3Provider } from '@ethersproject/providers/lib/web3-provider';

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -87,7 +87,11 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 					//metamask may get stuck due to eth_requestAccounts promise, if user close log in overlay
 					setTimeout(async () => {
 						const authorized = await injected.isAuthorized();
-						if (!authorized) window.location.reload();
+						if (
+							!authorized &&
+							localStorage.getItem('chosenWallet') === 'metamask'
+						)
+							addNotification('Cant connect?, please reload and retry');
 					}, 20000); //@todo: check if metamask solves this, issue #10085
 
 				await activate(c, async (e) => {

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -66,6 +66,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 	const walletContext = useWeb3React<Web3Provider>();
 	const { active, connector, activate, deactivate } = walletContext;
 	const [isLoading, setIsLoading] = useState(false); //state for trigger the loading spinner
+
 	//- Notification State
 	const { addNotification } = useNotification();
 

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -77,7 +77,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 		const c = connectorFromName(wallet) as AbstractConnector;
 
 		if (c) {
-			if (wallet === 'metamask' && window.ethereum === undefined) {
+			if (wallet === 'metamask' && !window.ethereum) {
 				//if user tries to connect metamask without provider
 				addNotification('no provider, start crypto wallets or get metamask');
 				setIsLoading(false);
@@ -89,27 +89,12 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 				if (previousWallet) await closeSession(previousWallet);
 				localStorage.setItem('chosenWallet', wallet); //sets the actual wallet key to reconnect if connected
 
-				if (wallet === 'metamask') {
-					if (window.ethereum) {
-						const { ethereum } = window as any;
-						const authorized = await injected.isAuthorized();
-						activate(c, undefined, true);
-						//if user its using brave browser, this may get stuck, but still handle the "accountsChanged"
-						//if using metamask extension, will connect and save the chosen wallet to reconnect again next time
-						if (!authorized)
-							ethereum.on('accountsChanged', async () => {
-								activate(c, undefined, true);
-								window.location.reload(); //reload and will get connected automatically
-							});
-					}
-				} else {
-					await activate(c, async (e: Error) => {
-						addNotification(`Failed to connect to wallet.`);
-						localStorage.removeItem('chosenWallet');
-						console.error(`Encounter error while connecting to ${wallet}.`);
-						console.error(e);
-					});
-				}
+				await activate(c, async (e: Error) => {
+					addNotification(`Failed to connect to wallet.`);
+					localStorage.removeItem('chosenWallet');
+					console.error(`Encounter error while connecting to ${wallet}.`);
+					console.error(e);
+				});
 
 				setIsLoading(false);
 				onConnect();

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -81,7 +81,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 				setIsLoading(false);
 			} else {
 				const previousWallet = localStorage.getItem('chosenWallet');
-				if (previousWallet) closeSession(previousWallet);
+				if (previousWallet) await closeSession(previousWallet);
 				localStorage.setItem('chosenWallet', wallet); //sets the actual wallet key to reconnect if connected
 
 				if (wallet === 'metamask')

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -77,7 +77,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 		if (c) {
 			if (wallet === 'metamask' && !window.ethereum) {
 				//if user tries to connect metamask without provider
-				addNotification('start or get wallet provider an reload');
+				addNotification('start or get wallet provider and reload');
 				setIsLoading(false);
 			} else {
 				const previousWallet = localStorage.getItem('chosenWallet');

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -81,6 +81,9 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 				//if user tries to connect metamask without provider
 				addNotification('no provider, start crypto wallets or get metamask');
 				setIsLoading(false);
+				setTimeout(() => {
+					window.location.reload(); //brave wont show first time the pop up to connect, this fix that
+				}, 1500);
 			} else {
 				const previousWallet = localStorage.getItem('chosenWallet');
 				if (previousWallet) await closeSession(previousWallet);
@@ -89,13 +92,12 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 				if (wallet === 'metamask') {
 					if (window.ethereum) {
 						const { ethereum } = window as any;
-						localStorage.removeItem('chosenWallet');
 						activate(c, undefined, true);
 						//if user its using brave browser, this may get stuck, but still handle the "accountsChanged"
 						//if using metamask extension, will connect and save the chosen wallet to reconnect again next time
 						ethereum.on('accountsChanged', () => {
-							localStorage.setItem('chosenWallet', wallet);
 							activate(c, undefined, true);
+							window.location.reload(); //reload and will get connected automatically
 						});
 					}
 				} else {
@@ -108,7 +110,6 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 				}
 
 				setIsLoading(false);
-
 				onConnect();
 			}
 		}

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -92,13 +92,15 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 				if (wallet === 'metamask') {
 					if (window.ethereum) {
 						const { ethereum } = window as any;
+						const authorized = await injected.isAuthorized();
 						activate(c, undefined, true);
 						//if user its using brave browser, this may get stuck, but still handle the "accountsChanged"
 						//if using metamask extension, will connect and save the chosen wallet to reconnect again next time
-						ethereum.on('accountsChanged', () => {
-							activate(c, undefined, true);
-							window.location.reload(); //reload and will get connected automatically
-						});
+						if (!authorized)
+							ethereum.on('accountsChanged', async () => {
+								activate(c, undefined, true);
+								window.location.reload(); //reload and will get connected automatically
+							});
 					}
 				} else {
 					await activate(c, async (e: Error) => {

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -83,7 +83,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 				setIsLoading(false);
 				setTimeout(() => {
 					window.location.reload(); //brave wont show first time the pop up to connect, this fix that
-				}, 1500);
+				}, 3000);
 			} else {
 				const previousWallet = localStorage.getItem('chosenWallet');
 				if (previousWallet) await closeSession(previousWallet);

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -89,8 +89,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 			onConnect();
 		}
 	};
-
-	const closeSession = (wallet: string) => {
+	const closeSession = async (wallet: string) => {
 		deactivate();
 		//if has a wallet connected, instead of just deactivate, close connection too
 		switch (wallet) {

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -95,7 +95,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 						//if using metamask extension, will connect and save the chosen wallet to reconnect again next time
 						ethereum.on('accountsChanged', () => {
 							localStorage.setItem('chosenWallet', wallet);
-							if (account === undefined) window.location.reload();
+							activate(c, undefined, true);
 						});
 					}
 				} else {

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -111,7 +111,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 		}
 	};
 
-	const closeSession = async (wallet: string) => {
+	const closeSession = (wallet: string) => {
 		deactivate();
 		//if has a wallet connected, instead of just deactivate, close connection too
 		switch (wallet) {

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -26,9 +26,6 @@ import coinbaseWalletIcon from './assets/coinbasewallet.svg';
 import fortmaticIcon from './assets/fortmatic.svg';
 import portisIcon from './assets/portis.svg';
 import useNotification from 'lib/hooks/useNotification';
-import { ethers } from 'ethers';
-import { useInactiveListener } from 'lib/hooks/provider-hooks';
-import { useRefreshToken } from 'lib/hooks/useRefreshToken';
 
 type ConnectToWalletProps = {
 	onConnect: () => void;

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -77,7 +77,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 		if (c) {
 			if (wallet === 'metamask' && !window.ethereum) {
 				//if user tries to connect metamask without provider
-				addNotification('start or get wallet provider and reload');
+				addNotification('Start or get wallet provider and reload');
 				setIsLoading(false);
 			} else {
 				const previousWallet = localStorage.getItem('chosenWallet');

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -81,7 +81,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 				setIsLoading(false);
 			} else {
 				const previousWallet = localStorage.getItem('chosenWallet');
-				if (previousWallet) await closeSession(previousWallet);
+				if (previousWallet) closeSession(previousWallet);
 				localStorage.setItem('chosenWallet', wallet); //sets the actual wallet key to reconnect if connected
 
 				if (wallet === 'metamask')

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -79,7 +79,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 		if (c) {
 			if (wallet === 'metamask' && !window.ethereum) {
 				//if user tries to connect metamask without provider
-				addNotification('no provider, start crypto wallets or get metamask');
+				addNotification('start or get wallet provider first');
 				setIsLoading(false);
 				setTimeout(() => {
 					window.location.reload(); //brave wont show first time the pop up to connect, this fix that

--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -76,11 +76,8 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 		if (c) {
 			if (wallet === 'metamask' && !window.ethereum) {
 				//if user tries to connect metamask without provider
-				addNotification('start or get wallet provider first');
+				addNotification('start or get wallet provider an reload');
 				setIsLoading(false);
-				setTimeout(() => {
-					window.location.reload(); //brave wont show first time the pop up to connect, this fix that
-				}, 3000);
 			} else {
 				const previousWallet = localStorage.getItem('chosenWallet');
 				if (previousWallet) await closeSession(previousWallet);

--- a/src/lib/hooks/provider-hooks.ts
+++ b/src/lib/hooks/provider-hooks.ts
@@ -14,14 +14,13 @@ export function useEagerConnect() {
 		const wallet = localStorage.getItem('chosenWallet');
 		const reConnectToWallet = async (wallet: string) => {
 			if (wallet === 'metamask') {
-				if (window.ethereum?.isMetaMask) {
-					//if metamask provider its active, it will try to connect
-					await injected.isAuthorized().then((isAuthorized: boolean) => {
-						if (isAuthorized) {
-							activate(injected, undefined, true);
-						}
-					});
-				} else localStorage.removeItem('chosenWallet');
+				await injected.isAuthorized().then((isAuthorized: boolean) => {
+					//if user is authorized then connect
+					if (isAuthorized) activate(injected, undefined, true);
+					//if not authorized then not try to recoonect next time
+					//same case if there is no provider
+					else localStorage.removeItem('chosenWallet');
+				});
 			} else {
 				const c = connectorFromName(wallet) as AbstractConnector;
 				if (c) {

--- a/src/lib/hooks/provider-hooks.ts
+++ b/src/lib/hooks/provider-hooks.ts
@@ -6,7 +6,7 @@ import { connectorFromName } from 'components/ConnectToWallet/ConnectToWallet';
 import { AbstractConnector } from '@web3-react/abstract-connector';
 
 export function useEagerConnect() {
-	const { activate, deactivate, active } = useWeb3React();
+	const { activate, active } = useWeb3React();
 
 	const [tried, setTried] = useState(false);
 
@@ -14,19 +14,14 @@ export function useEagerConnect() {
 		const wallet = localStorage.getItem('chosenWallet');
 		const reConnectToWallet = async (wallet: string) => {
 			if (wallet === 'metamask') {
-				setTimeout(() => {
-					//timeout if user lost session and page tries to reconnect forever
-					if (!active) {
-						localStorage.removeItem('chosenWallet');
-						setTried(false);
-					}
-				}, 5000);
-
-				await injected.isAuthorized().then((isAuthorized: boolean) => {
-					if (isAuthorized) {
-						activate(injected, undefined, true);
-					}
-				});
+				if (window.ethereum?.isMetaMask) {
+					//if metamask provider its active, it will try to connect
+					await injected.isAuthorized().then((isAuthorized: boolean) => {
+						if (isAuthorized) {
+							activate(injected, undefined, true);
+						}
+					});
+				} else localStorage.removeItem('chosenWallet');
 			} else {
 				const c = connectorFromName(wallet) as AbstractConnector;
 				if (c) {
@@ -97,4 +92,7 @@ export function useInactiveListener(suppress: boolean = false) {
 			};
 		}
 	}, [active, error, suppress, activate]);
+}
+function addNotification(arg0: string) {
+	throw new Error('Function not implemented.');
 }

--- a/src/lib/hooks/provider-hooks.ts
+++ b/src/lib/hooks/provider-hooks.ts
@@ -17,7 +17,7 @@ export function useEagerConnect() {
 				await injected.isAuthorized().then((isAuthorized: boolean) => {
 					//if user is authorized then connect
 					if (isAuthorized) activate(injected, undefined, true);
-					//if not authorized then not try to reconect next time
+					//if not authorized then not try to reconnect next time
 					//same case if there is no provider
 					else localStorage.removeItem('chosenWallet');
 				});

--- a/src/lib/hooks/provider-hooks.ts
+++ b/src/lib/hooks/provider-hooks.ts
@@ -17,7 +17,7 @@ export function useEagerConnect() {
 				await injected.isAuthorized().then((isAuthorized: boolean) => {
 					//if user is authorized then connect
 					if (isAuthorized) activate(injected, undefined, true);
-					//if not authorized then not try to recoonect next time
+					//if not authorized then not try to reconect next time
 					//same case if there is no provider
 					else localStorage.removeItem('chosenWallet');
 				});

--- a/src/lib/hooks/provider-hooks.ts
+++ b/src/lib/hooks/provider-hooks.ts
@@ -92,6 +92,3 @@ export function useInactiveListener(suppress: boolean = false) {
 		}
 	}, [active, error, suppress, activate]);
 }
-function addNotification(arg0: string) {
-	throw new Error('Function not implemented.');
-}


### PR DESCRIPTION
This error its generated by the lost of authorization to connect, page shouldnt try to reconnect if user isnt authorized yet

Also Metamask may get stuck with requestAccounts promise if user close login overlay, for this, page will try to detect if its stuck and reload, or ask user to reload with a timeout if promise cant resolve. Other DAPPS like opensea / pancakewap / hypertext, displays an error message and ask user to reload

Flow:
User has metamask extension? works OK
User has brave and load crypto wallets at start enabled? works OK

User has brave and not enabled crypto wallets or metamask extension?
-First pop up message asking for extension or crypto wallets to start and reload
-Second when user has the provider available pop ups log in overlay
-Last, if log in sucess, then reloads if necessary and its OK