### PR TITLE
Bid history should show your own bids

### DIFF
--- a/src/components/Tables/DomainTable/DomainTable.tsx
+++ b/src/components/Tables/DomainTable/DomainTable.tsx
@@ -37,7 +37,7 @@ import { useRefreshToken } from 'lib/hooks/useRefreshToken';
 type DomainTableProps = {
 	className?: string;
 	disableButton?: boolean;
-	filterOwnerBids?: boolean;
+	filterOwnBids?: boolean;
 	domains: Domain[];
 	empty?: boolean;
 	isButtonActive?: (row: any) => boolean;
@@ -61,7 +61,7 @@ enum Modals {
 const DomainTable: React.FC<DomainTableProps> = ({
 	className,
 	disableButton,
-	filterOwnerBids,
+	filterOwnBids,
 	domains,
 	empty,
 	isButtonActive,
@@ -220,7 +220,7 @@ const DomainTable: React.FC<DomainTableProps> = ({
 						<NumBids
 							domain={domain}
 							refreshKey={domainToRefresh}
-							filterOwnerBids={filterOwnerBids}
+							filterOwnBids={filterOwnBids}
 						/>
 					</div>
 				),
@@ -247,7 +247,7 @@ const DomainTable: React.FC<DomainTableProps> = ({
 									style={{ marginLeft: 'auto', textTransform: 'uppercase' }}
 									domain={domain}
 									onClick={onRowButtonClick}
-									filterOwnerBids={filterOwnerBids}
+									filterOwnBids={filterOwnBids}
 								/>
 							)}
 						</>

--- a/src/components/Tables/DomainTable/DomainTable.tsx
+++ b/src/components/Tables/DomainTable/DomainTable.tsx
@@ -40,7 +40,6 @@ type DomainTableProps = {
 	filterOwnerBids?: boolean;
 	domains: Domain[];
 	empty?: boolean;
-	hideOwnBids?: boolean;
 	isButtonActive?: (row: any) => boolean;
 	isGlobalTable?: boolean;
 	isGridView?: boolean;
@@ -65,7 +64,6 @@ const DomainTable: React.FC<DomainTableProps> = ({
 	filterOwnerBids,
 	domains,
 	empty,
-	hideOwnBids,
 	isButtonActive,
 	isGlobalTable,
 	isGridView,

--- a/src/components/Tables/DomainTable/DomainTable.tsx
+++ b/src/components/Tables/DomainTable/DomainTable.tsx
@@ -37,6 +37,7 @@ import { useRefreshToken } from 'lib/hooks/useRefreshToken';
 type DomainTableProps = {
 	className?: string;
 	disableButton?: boolean;
+	filterOwnerBids?: boolean;
 	domains: Domain[];
 	empty?: boolean;
 	hideOwnBids?: boolean;
@@ -61,6 +62,7 @@ enum Modals {
 const DomainTable: React.FC<DomainTableProps> = ({
 	className,
 	disableButton,
+	filterOwnerBids,
 	domains,
 	empty,
 	hideOwnBids,
@@ -217,7 +219,11 @@ const DomainTable: React.FC<DomainTableProps> = ({
 				id: 'numBids',
 				accessor: (domain: Domain) => (
 					<div style={{ textAlign: 'right' }}>
-						<NumBids domain={domain} refreshKey={domainToRefresh} />
+						<NumBids
+							domain={domain}
+							refreshKey={domainToRefresh}
+							filterOwnerBids={filterOwnerBids}
+						/>
 					</div>
 				),
 			},

--- a/src/components/Tables/DomainTable/DomainTable.tsx
+++ b/src/components/Tables/DomainTable/DomainTable.tsx
@@ -249,6 +249,7 @@ const DomainTable: React.FC<DomainTableProps> = ({
 									style={{ marginLeft: 'auto', textTransform: 'uppercase' }}
 									domain={domain}
 									onClick={onRowButtonClick}
+									filterOwnerBids={filterOwnerBids}
 								/>
 							)}
 						</>

--- a/src/components/Tables/DomainTable/components/NumBids.tsx
+++ b/src/components/Tables/DomainTable/components/NumBids.tsx
@@ -9,9 +9,14 @@ import { Domain } from 'lib/types';
 type NumBidsProps = {
 	domain: Domain;
 	refreshKey: string;
+	filterOwnerBids?: boolean;
 };
 
-const NumBids: React.FC<NumBidsProps> = ({ domain, refreshKey }) => {
+const NumBids: React.FC<NumBidsProps> = ({
+	domain,
+	refreshKey,
+	filterOwnerBids,
+}) => {
 	let isMounted = useRef(false);
 	const { getBidsForDomain } = useBidProvider();
 	const [numBids, setNumBids] = useState<number | undefined>();
@@ -20,7 +25,7 @@ const NumBids: React.FC<NumBidsProps> = ({ domain, refreshKey }) => {
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 
 	const getBids = async () => {
-		const bids = await getBidsForDomain(domain);
+		const bids = await getBidsForDomain(domain, filterOwnerBids);
 
 		if (!isMounted.current) return;
 

--- a/src/components/Tables/DomainTable/components/NumBids.tsx
+++ b/src/components/Tables/DomainTable/components/NumBids.tsx
@@ -9,13 +9,13 @@ import { Domain } from 'lib/types';
 type NumBidsProps = {
 	domain: Domain;
 	refreshKey: string;
-	filterOwnerBids?: boolean;
+	filterOwnBids?: boolean;
 };
 
 const NumBids: React.FC<NumBidsProps> = ({
 	domain,
 	refreshKey,
-	filterOwnerBids,
+	filterOwnBids,
 }) => {
 	let isMounted = useRef(false);
 	const { getBidsForDomain } = useBidProvider();
@@ -25,7 +25,7 @@ const NumBids: React.FC<NumBidsProps> = ({
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 
 	const getBids = async () => {
-		const bids = await getBidsForDomain(domain, filterOwnerBids);
+		const bids = await getBidsForDomain(domain, filterOwnBids);
 
 		if (!isMounted.current) return;
 

--- a/src/components/Tables/DomainTable/components/ViewBids.tsx
+++ b/src/components/Tables/DomainTable/components/ViewBids.tsx
@@ -9,14 +9,14 @@ type ViewBidsProps = {
 	domain: Domain;
 	onClick: (domain: DomainData) => void;
 	style?: React.CSSProperties;
-	filterOwnerBids?: boolean;
+	filterOwnBids?: boolean;
 };
 
 const ViewBids: React.FC<ViewBidsProps> = ({
 	domain,
 	onClick,
 	style,
-	filterOwnerBids,
+	filterOwnBids,
 }) => {
 	let isMounted = useRef(false);
 
@@ -34,7 +34,7 @@ const ViewBids: React.FC<ViewBidsProps> = ({
 	};
 
 	const getBids = async () => {
-		const bids = await getBidsForDomain(domain, filterOwnerBids);
+		const bids = await getBidsForDomain(domain, filterOwnBids);
 		if (!isMounted.current) return;
 		setIsLoading(false);
 		if (bids && bids.length) setBids(bids);

--- a/src/components/Tables/DomainTable/components/ViewBids.tsx
+++ b/src/components/Tables/DomainTable/components/ViewBids.tsx
@@ -9,9 +9,15 @@ type ViewBidsProps = {
 	domain: Domain;
 	onClick: (domain: DomainData) => void;
 	style?: React.CSSProperties;
+	filterOwnerBids?: boolean;
 };
 
-const ViewBids: React.FC<ViewBidsProps> = ({ domain, onClick, style }) => {
+const ViewBids: React.FC<ViewBidsProps> = ({
+	domain,
+	onClick,
+	style,
+	filterOwnerBids,
+}) => {
 	let isMounted = useRef(false);
 
 	const { getBidsForDomain } = useBidProvider();
@@ -28,7 +34,7 @@ const ViewBids: React.FC<ViewBidsProps> = ({ domain, onClick, style }) => {
 	};
 
 	const getBids = async () => {
-		const bids = await getBidsForDomain(domain, true);
+		const bids = await getBidsForDomain(domain, filterOwnerBids);
 		if (!isMounted.current) return;
 		setIsLoading(false);
 		if (bids && bids.length) setBids(bids);

--- a/src/components/Tables/DomainTable/components/ViewBids.tsx
+++ b/src/components/Tables/DomainTable/components/ViewBids.tsx
@@ -28,7 +28,7 @@ const ViewBids: React.FC<ViewBidsProps> = ({ domain, onClick, style }) => {
 	};
 
 	const getBids = async () => {
-		const bids = await getBidsForDomain(domain);
+		const bids = await getBidsForDomain(domain, true);
 		if (!isMounted.current) return;
 		setIsLoading(false);
 		if (bids && bids.length) setBids(bids);

--- a/src/containers/OwnedDomainsTable/OwnedDomainsTable.tsx
+++ b/src/containers/OwnedDomainsTable/OwnedDomainsTable.tsx
@@ -217,6 +217,7 @@ const OwnedDomainTables: React.FC<OwnedDomainTableProps> = ({ onNavigate }) => {
 				domains={owned}
 				hideOwnBids
 				isButtonActive={isButtonActive}
+				filterOwnerBids={true}
 				isRootDomain={false}
 				rowButtonText={'View Bids'}
 				onLoad={tableLoaded}

--- a/src/containers/OwnedDomainsTable/OwnedDomainsTable.tsx
+++ b/src/containers/OwnedDomainsTable/OwnedDomainsTable.tsx
@@ -215,7 +215,6 @@ const OwnedDomainTables: React.FC<OwnedDomainTableProps> = ({ onNavigate }) => {
 			<DomainTable
 				className={styles.Reset}
 				domains={owned}
-				hideOwnBids
 				isButtonActive={isButtonActive}
 				filterOwnerBids={true}
 				isRootDomain={false}

--- a/src/containers/OwnedDomainsTable/OwnedDomainsTable.tsx
+++ b/src/containers/OwnedDomainsTable/OwnedDomainsTable.tsx
@@ -216,7 +216,7 @@ const OwnedDomainTables: React.FC<OwnedDomainTableProps> = ({ onNavigate }) => {
 				className={styles.Reset}
 				domains={owned}
 				isButtonActive={isButtonActive}
-				filterOwnerBids={true}
+				filterOwnBids={true}
 				isRootDomain={false}
 				rowButtonText={'View Bids'}
 				onLoad={tableLoaded}

--- a/src/lib/providers/BidProvider.tsx
+++ b/src/lib/providers/BidProvider.tsx
@@ -17,7 +17,7 @@ import { useChainSelector } from './ChainSelectorProvider';
 export const BidContext = React.createContext({
 	getBidsForDomain: async (
 		domain: Domain,
-		filterOwnerBids?: boolean,
+		filterOwnBids?: boolean,
 	): Promise<Bid[] | undefined> => {
 		return;
 	},
@@ -177,10 +177,7 @@ const BidProvider: React.FC<BidProviderType> = ({ children }) => {
 		};
 	}
 
-	const getBidsForDomain = async (
-		domain: Domain,
-		filterOwnerBids?: boolean,
-	) => {
+	const getBidsForDomain = async (domain: Domain, filterOwnBids?: boolean) => {
 		if (baseApiUri === undefined) {
 			throw Error(`no api endpoint`);
 		}
@@ -192,7 +189,7 @@ const BidProvider: React.FC<BidProviderType> = ({ children }) => {
 			)) as zAuction.BidDto[];
 
 			try {
-				if (filterOwnerBids)
+				if (filterOwnBids)
 					bids = bids.filter((e) => {
 						return e.account.toLowerCase() !== domain.owner.id.toLowerCase();
 					});

--- a/src/lib/providers/BidProvider.tsx
+++ b/src/lib/providers/BidProvider.tsx
@@ -15,7 +15,10 @@ import { useZAuctionBaseApiUri } from 'lib/hooks/useZAuctionBaseApiUri';
 import { useChainSelector } from './ChainSelectorProvider';
 
 export const BidContext = React.createContext({
-	getBidsForDomain: async (domain: Domain): Promise<Bid[] | undefined> => {
+	getBidsForDomain: async (
+		domain: Domain,
+		filterOwnerBids?: boolean,
+	): Promise<Bid[] | undefined> => {
 		return;
 	},
 	getBidsForAccount: async (id: string): Promise<Bid[] | undefined> => {
@@ -174,7 +177,10 @@ const BidProvider: React.FC<BidProviderType> = ({ children }) => {
 		};
 	}
 
-	const getBidsForDomain = async (domain: Domain) => {
+	const getBidsForDomain = async (
+		domain: Domain,
+		filterOwnerBids?: boolean,
+	) => {
 		if (baseApiUri === undefined) {
 			throw Error(`no api endpoint`);
 		}
@@ -186,6 +192,11 @@ const BidProvider: React.FC<BidProviderType> = ({ children }) => {
 			)) as zAuction.BidDto[];
 
 			try {
+				if (filterOwnerBids)
+					bids = bids.filter((e) => {
+						return e.account.toLowerCase() !== domain.owner.id.toLowerCase();
+					});
+
 				let displayBids = bids.map((e) => {
 					return getBidParameters(e, domain.id);
 				});

--- a/src/lib/providers/BidProvider.tsx
+++ b/src/lib/providers/BidProvider.tsx
@@ -189,10 +189,11 @@ const BidProvider: React.FC<BidProviderType> = ({ children }) => {
 			)) as zAuction.BidDto[];
 
 			try {
-				if (filterOwnBids)
+				if (filterOwnBids) {
 					bids = bids.filter((e) => {
 						return e.account.toLowerCase() !== domain.owner.id.toLowerCase();
 					});
+				}
 
 				let displayBids = bids.map((e) => {
 					return getBidParameters(e, domain.id);

--- a/src/lib/providers/BidProvider.tsx
+++ b/src/lib/providers/BidProvider.tsx
@@ -186,10 +186,6 @@ const BidProvider: React.FC<BidProviderType> = ({ children }) => {
 			)) as zAuction.BidDto[];
 
 			try {
-				bids = bids.filter((e) => {
-					return e.account.toLowerCase() !== domain.owner.id.toLowerCase();
-				});
-
 				let displayBids = bids.map((e) => {
 					return getBidParameters(e, domain.id);
 				});


### PR DESCRIPTION
Changed filter to be optional, and setted from domainTable component props.
Bid history on nftview will display and use the data for all bids, including the ones from the current owner of the domain.
My domains tab in profile, will show only the bids from other users