### PR TITLE
Fixed bug where NFT Card image in grid view wouldn't update between domains

### DIFF
--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -19,6 +19,11 @@ const Image = (props: any) => {
 	};
 
 	useEffect(() => {
+		setTryVideo(false);
+		setLoaded(false);
+	}, [props.src]);
+
+	useEffect(() => {
 		if (!refVideo.current) {
 			return;
 		}


### PR DESCRIPTION
Steps to re-create (before fix):
- Open Grid View
- Navigate to rational.emoji.testmov
- Go back to rational.emoji
- The image in the first NFT Card (Monstera) shouldn't load

Fixed by resetting the `tryVideo` state object in `Image.tsx`. The NFT Card components are being re-used, so if the nested Image was previously a video it will try nest the incoming image in a `<video>` tag - this obviously won't work.