### PR TITLE
Updates to Image component to allow for video controls (including bugfixes for iOS)

### DIFF
--- a/src/components/Artwork/Artwork.module.css
+++ b/src/components/Artwork/Artwork.module.css
@@ -13,7 +13,6 @@
 	min-width: 40px;
 	border-radius: 50%;
 	margin-right: 12px;
-	/* background-color: rgba(0,0,0,0.5); */
 	overflow: hidden;
 	cursor: pointer;
 	transition: transform var(--animation-time-medium) ease-in-out;
@@ -33,6 +32,13 @@
 .Image > * {
 	height: 100%;
 	width: 100%;
+}
+
+.Image img,
+.Image video {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
 }
 
 .Info {

--- a/src/components/Cards/PreviewCard/PreviewCard.tsx
+++ b/src/components/Cards/PreviewCard/PreviewCard.tsx
@@ -165,7 +165,12 @@ const PreviewCard: React.FC<PreviewCardProps> = ({
 							}`}
 							onClick={clickImage}
 						>
-							<Image unmute style={{ objectFit: 'contain' }} src={image} />
+							<Image
+								controls
+								unmute
+								style={{ objectFit: 'contain' }}
+								src={image}
+							/>
 						</div>
 						<div className={styles.InfoContainer}>
 							{body()}

--- a/src/components/Image/Image.module.css
+++ b/src/components/Image/Image.module.css
@@ -1,3 +1,9 @@
+.Container {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
 .Loading {
 	position: absolute;
 	top: 0;
@@ -11,9 +17,8 @@
 }
 
 .Image {
-	height: 100%;
-	width: 100%;
-	max-height: inherit;
+	max-height: 100%;
+	max-width: 100%;
 	transition: opacity var(--animation-time-medium) ease-in-out;
 }
 

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -39,7 +39,7 @@ const Image = (props: any) => {
 	};
 
 	const click = (event: any) => {
-		if (!loaded || props.controls) {
+		if (!loaded || (mediaType === MediaType.Video && props.controls)) {
 			event.stopPropagation();
 		}
 	};

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -16,7 +16,6 @@ const Image = (props: any) => {
 	const refVideo = useRef<HTMLVideoElement | undefined>(null);
 	const [loaded, setLoaded] = useState(false);
 
-	const [blobUrl, setBlobUrl] = useState<string | undefined>();
 	const [mediaType, setMediaType] = useState<MediaType | undefined>();
 	const [loadedSrc, setLoadedSrc] = useState<string | undefined>();
 	const [loadingSrc, setLoadingSrc] = useState<string | undefined>();
@@ -56,6 +55,13 @@ const Image = (props: any) => {
 		};
 	}, []);
 
+	/* Get type of media in src
+		 There's no indication from the IPFS url as to whether
+		 we're loading an image or a video, which is important
+		 for rendering the correct tags.
+
+		 Fetch the blob first and check file type before rendering
+	*/
 	useEffect(() => {
 		if (
 			!props.src ||
@@ -86,13 +92,7 @@ const Image = (props: any) => {
 				}
 
 				const type = getMediaType(blob.type);
-				const url = URL.createObjectURL(blob);
-				if (!url || type === undefined) {
-					throw 'Failed to create blob from IPFS url';
-				}
 				setMediaType(type);
-				setBlobUrl(url);
-				setLoaded(true);
 				setLoadedSrc(r.url);
 				setLoadingSrc(undefined);
 			} catch (e: any) {
@@ -135,7 +135,8 @@ const Image = (props: any) => {
 						objectFit: 'cover',
 						...props.style,
 					}}
-					src={blobUrl}
+					onLoad={load}
+					src={props.src}
 					alt={props.alt || ''}
 					onClick={click}
 				/>
@@ -154,7 +155,7 @@ const Image = (props: any) => {
 						objectFit: 'cover',
 						...props.style,
 					}}
-					src={blobUrl}
+					src={props.src}
 					preload="metadata"
 					onLoadedMetadata={load}
 					muted

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,36 +1,110 @@
 import { useEffect, useState, useRef } from 'react';
 
 import styles from './Image.module.css';
-// import placeholder from './'
 
-// @TODO: Refactor props to not by 'any' type
+enum MediaType {
+	Image,
+	Video,
+}
+
+// Note:
+// This component is being re-written in another
+// branch - this is just a hotfix to get videos
+// working on mobile
 const Image = (props: any) => {
+	const isMounted = useRef(false);
 	const refVideo = useRef<HTMLVideoElement | undefined>(null);
 	const [loaded, setLoaded] = useState(false);
-	const [tryVideo, setTryVideo] = useState(false);
+
+	const [blobUrl, setBlobUrl] = useState<string | undefined>();
+	const [mediaType, setMediaType] = useState<MediaType | undefined>();
+	const [loadedSrc, setLoadedSrc] = useState<string | undefined>();
+	const [loadingSrc, setLoadingSrc] = useState<string | undefined>();
 
 	const containerRef = useRef<HTMLDivElement>(null);
 
+	///////////////
+	// Functions //
+	///////////////
+
 	const load = () => setLoaded(true);
-	const err = (e: any) => {
-		if (props.src) {
-			setTryVideo(true);
+
+	const getMediaType = (typeFromBlob: string) => {
+		if (typeFromBlob.indexOf('image') > -1) {
+			return MediaType.Image;
+		} else if (typeFromBlob.indexOf('video') > -1) {
+			return MediaType.Video;
+		} else {
+			return undefined;
 		}
 	};
 
+	const click = (event: any) => {
+		if (!loaded || props.controls) {
+			event.stopPropagation();
+		}
+	};
+
+	/////////////
+	// Effects //
+	/////////////
+
 	useEffect(() => {
-		if (!refVideo.current) {
+		isMounted.current = true;
+		return () => {
+			isMounted.current = false;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (
+			!props.src ||
+			props.src.length === 0 ||
+			props.src === loadedSrc ||
+			(loadingSrc && props.src === loadingSrc)
+		) {
 			return;
 		}
+		setLoaded(false);
+		setLoadingSrc(props.src);
+		fetch(props.src).then(async (r: Response) => {
+			// Check that the URL hasn't switched between
+			// making the fetch and receiving data
+			if (r.url !== props.src || !isMounted.current) {
+				return;
+			}
+			if (r.status !== 200) {
+				throw 'Failed to retrieve media data at ' + props.src;
+			}
 
-		if (props.unmute) {
-			refVideo.current.defaultMuted = false;
-			refVideo.current.muted = false;
-		} else {
-			refVideo.current.defaultMuted = true;
-			refVideo.current.muted = true;
-		}
-	}, [tryVideo, props.unmute]);
+			try {
+				const blob = await r.blob();
+
+				// Check again since we had an async call
+				if (r.url !== props.src || !isMounted.current) {
+					return;
+				}
+
+				const type = getMediaType(blob.type);
+				const url = URL.createObjectURL(blob);
+				if (!url || type === undefined) {
+					throw 'Failed to create blob from IPFS url';
+				}
+				setMediaType(type);
+				setBlobUrl(url);
+				setLoaded(true);
+				setLoadedSrc(r.url);
+				setLoadingSrc(undefined);
+			} catch (e: any) {
+				console.error(e);
+				return;
+			}
+		});
+	}, [props.src]);
+
+	////////////
+	// Render //
+	////////////
 
 	return (
 		<div
@@ -39,17 +113,18 @@ const Image = (props: any) => {
 				position: 'relative',
 				width: '100%',
 				height: '100%',
-				display: 'inline-block',
 				maxHeight: 'inherit',
 				...props.style,
 			}}
+			className={styles.Container}
+			onClick={click}
 		>
 			{!loaded && (
 				<div {...props} className={styles.Loading}>
 					<div className={styles.Spinner}></div>
 				</div>
 			)}
-			{!tryVideo && (
+			{mediaType === MediaType.Image && (
 				<img
 					{...props}
 					className={`${props.className ? props.className : ''} ${
@@ -60,16 +135,15 @@ const Image = (props: any) => {
 						objectFit: 'cover',
 						...props.style,
 					}}
-					onLoad={load}
-					src={props.src}
+					src={blobUrl}
 					alt={props.alt || ''}
-					onError={err}
+					onClick={click}
 				/>
 			)}
-			{tryVideo && (
+			{mediaType === MediaType.Video && (
 				<video
 					{...props}
-					autoPlay
+					autoPlay="auto"
 					loop
 					ref={refVideo}
 					className={`${props.className ? props.className : ''} ${
@@ -80,9 +154,12 @@ const Image = (props: any) => {
 						objectFit: 'cover',
 						...props.style,
 					}}
+					src={blobUrl}
 					preload="metadata"
 					onLoadedMetadata={load}
+					muted
 					playsInline
+					onClick={click}
 				/>
 			)}
 		</div>

--- a/src/containers/MakeABid/MakeABid.tsx
+++ b/src/containers/MakeABid/MakeABid.tsx
@@ -326,6 +326,7 @@ const MakeABid: React.FC<MakeABidProps> = ({ domain, onBid }) => {
 	const nft = () => (
 		<div className={styles.NFT}>
 			<Image
+				controls
 				style={{ objectFit: 'contain', position: 'absolute', zIndex: 2 }}
 				src={domainMetadata?.image}
 			/>

--- a/src/containers/NFTView/NFTView.tsx
+++ b/src/containers/NFTView/NFTView.tsx
@@ -317,6 +317,7 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 							borderWidth: 2,
 							objectFit: 'contain',
 						}}
+						controls
 						unmute
 						className="border-radius"
 						src={znsDomain.domain?.image ?? ''}

--- a/src/containers/Request/Request.tsx
+++ b/src/containers/Request/Request.tsx
@@ -129,6 +129,7 @@ const Request: React.FC<RequestProps> = ({
 				>
 					<div>
 						<Image
+							controls
 							src={metadata?.image || ''}
 							style={{
 								width: 'auto',
@@ -191,7 +192,7 @@ const Request: React.FC<RequestProps> = ({
 
 			{/* Preview Image (Clickable) */}
 			<div className={styles.Image}>
-				<Image src={metadata?.image} onClick={preview} />
+				<Image controls src={metadata?.image} onClick={preview} />
 			</div>
 
 			{/* Requested Domain Info (Name, description, etc.) */}

--- a/src/containers/TransferOwnership/TransferOwnership.tsx
+++ b/src/containers/TransferOwnership/TransferOwnership.tsx
@@ -120,7 +120,7 @@ const TransferOwnership: React.FC<TransferOwnershipProps> = ({
 						style={{ display: 'flex', padding: '0 37.5px' }}
 					>
 						<div className={styles.NFT}>
-							<Image src={image} />
+							<Image controls src={image} />
 						</div>
 
 						<div className={styles.Details}>


### PR DESCRIPTION
**zer0 task:** https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/0177518e-9583-408b-be96-6eca6a2209f6

**Loom:** https://www.loom.com/share/4d2882f237f04f8d8ea34bc3bb5a85fa

_______________

Previously, Image components would just play videos by default with sound on. Unfortunately (for devs, fortunately for users) browsers are pretty strict on autoplaying videos with audio, especially on mobile devices. Instead of coming up with a hacky solution, for now it will just be best to show the default video controls.

`Image.tsx` was previously failing to load videos nicely on iOS - it would load them into an `<img>` which obviously was preventing controls from appearing. And, since audio is disabled by default in iOS, it meant you couldn't turn audio on.

1.  Rewrote `Image.tsx` to get media type and put it in either a `<video>` or `<img>` depending on the content.
2. Added controls to videos (on all devices)
3. Made videos muted by default, per UX guidelines given (enforced) by browsers
3. Prevented image lightbox on clicking videos with controls (to prevent a double-fullscreen situation)

Test:
1. Navigate to `wilder.rational.emoji` on Kovan
2. Should be 3 video NFTs playing in domain list (`Sound Sample`, `Test Mov`,  `WOW Test Video`) - none of these will have sound or video controls
3. Navigate to `wilder.rational.emoji.soundsample`
4. NFT preview video should be autoplaying with no sound and video controls enabled. Clicking it should not open it in the lightbox.
5. Navigate to NFT view `wilder.rational.emoji.soundsample?view`
6. Repeat step 4