### PR TITLE
FIX Blank overlay if user press "make a bid" button disconnected

### DIFF
--- a/src/containers/NFTView/NFTView.tsx
+++ b/src/containers/NFTView/NFTView.tsx
@@ -97,7 +97,7 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 
 	const openBidOverlay = () => {
 		if (!isMounted.current) return;
-		if (!znsDomain.domain || isOwnedByYou) return;
+		if (!znsDomain.domain || isOwnedByYou || !active) return;
 		setIsBidOverlayOpen(true);
 	};
 


### PR DESCRIPTION
Steps to reproduce:
Disconnect wallet
Navigate to NFT View of any domain
Hit "Make A Bid"
A blank semi-transparent black overlay will mask the UI