### PR TITLE
Post-release mobile tweaks

### DIFF
--- a/src/components/Buttons/IconButton/IconButton.tsx
+++ b/src/components/Buttons/IconButton/IconButton.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import styles from './IconButton.module.css';
 
 type IconButtonProps = {
+	className?: string;
 	toggleable?: boolean;
 	iconUri: string;
 	style?: React.CSSProperties;
@@ -13,6 +14,7 @@ type IconButtonProps = {
 };
 
 const IconButton: React.FC<IconButtonProps> = ({
+	className,
 	toggleable,
 	toggled,
 	iconUri,
@@ -37,7 +39,7 @@ const IconButton: React.FC<IconButtonProps> = ({
 			onClick={handleClick}
 			className={`${styles.iconButton} ${
 				(toggleable && selected) || toggled ? styles.selected : ''
-			} ${disabled ? styles.Disabled : ''}`}
+			} ${disabled ? styles.Disabled : ''} ${className ? className : ''}`}
 		>
 			<img alt={altText} src={iconUri} />
 		</button>

--- a/src/components/NavBars/TitleBar/TitleBar.module.css
+++ b/src/components/NavBars/TitleBar/TitleBar.module.css
@@ -232,7 +232,7 @@ header {
 	}
 }
 
-@media only screen and (max-width: 370px) {
+@media only screen and (max-width: 500px) {
 	.Search {
 		display: none;
 	}

--- a/src/components/NavBars/TitleBar/TitleBar.module.css
+++ b/src/components/NavBars/TitleBar/TitleBar.module.css
@@ -231,3 +231,9 @@ header {
 		margin-top: 4px;
 	}
 }
+
+@media only screen and (max-width: 370px) {
+	.Search {
+		display: none;
+	}
+}

--- a/src/components/Overlay/Overlay.module.css
+++ b/src/components/Overlay/Overlay.module.css
@@ -16,7 +16,7 @@
 	z-index: 9000;
 	opacity: 0;
 
-	background: rgba(0, 0, 0, 0.7);
+	background: rgba(0, 0, 0, 0.9);
 	transition: backdrop-filter 0.2s;
 }
 
@@ -63,6 +63,13 @@
 
 	/* @todo temporarily disabled backdrop blur for performance */
 	/* backdrop-filter: blur(30px) opacity(0); */
+}
+
+.Close {
+	position: fixed;
+	top: 32px;
+	right: 32px;
+	background: rgba(255, 255, 255, 0.1);
 }
 
 @keyframes open {

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -2,8 +2,12 @@
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
+import { IconButton } from 'components';
+
 //- Style Imports
 import styles from './Overlay.module.css';
+
+import closeIcon from 'assets/close-icon.svg';
 
 type OverlayProps = {
 	onClose: () => void;
@@ -14,6 +18,7 @@ type OverlayProps = {
 	img?: boolean;
 	fullScreen?: boolean;
 	style?: React.CSSProperties;
+	hasCloseButton?: boolean;
 };
 
 const Overlay: React.FC<OverlayProps> = ({
@@ -25,6 +30,7 @@ const Overlay: React.FC<OverlayProps> = ({
 	nested,
 	fullScreen,
 	style,
+	hasCloseButton,
 }) => {
 	const [inDOM, setInDOM] = useState<boolean>(false);
 	const [domId, setDomId] = useState('');
@@ -94,6 +100,12 @@ const Overlay: React.FC<OverlayProps> = ({
 			} ${centered ? styles.Centered : ''}
 			${fullScreen ? styles.FullScreen : ''}`}
 		>
+			<IconButton
+				className={styles.Close}
+				onClick={onClose}
+				iconUri={closeIcon}
+				style={{ height: 32, width: 32, padding: 6 }}
+			/>
 			<div className={`overlay ${styles.Container} ${img ? styles.Image : ''}`}>
 				{children}
 				<div style={{ display: centered ? 'none' : 'block', height: 64 }}></div>

--- a/src/containers/NFTView/NFTView.module.css
+++ b/src/containers/NFTView/NFTView.module.css
@@ -38,6 +38,7 @@
 	height: 100%;
 	z-index: -1;
 	object-fit: cover;
+	border-radius: var(--box-radius);
 }
 
 .NFT > div {

--- a/src/pages/ZNS/ZNS.tsx
+++ b/src/pages/ZNS/ZNS.tsx
@@ -183,6 +183,10 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 		setForwardDomain(undefined);
 	};
 
+	const scrollToTop = () => {
+		document.querySelector('body')?.scrollTo(0, 0);
+	};
+
 	/////////////////////
 	// Overlay Toggles //
 	/////////////////////
@@ -236,11 +240,12 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 		}
 		lastDomain.current = domain;
 		pageHistory.current = pageHistory.current.concat([domain]);
-		window.scrollTo(0, 0); // scroll to top whenever we change domain
+		scrollToTop();
 	}, [domain]);
 
 	/* WIP */
 	useEffect(() => {
+		scrollToTop();
 		setShowDomainTable(!isNftView);
 	}, [isNftView]);
 
@@ -287,6 +292,10 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 			setTableData(znsDomain.domain.subdomains);
 			setHasLoaded(true);
 		}
+		window.scrollTo({
+			top: -1000,
+			behavior: 'smooth',
+		});
 	}, [znsDomain.domain, hasLoaded]);
 
 	/////////////////////

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -340,6 +340,7 @@ nav {
 		100% - (var(--page-padding) * 2) - 6px
 	); /* Not sure why the -6 is needed, temp fix */
 	max-width: calc(var(--width-max) - (var(--page-padding) * 2)) !important;
+	min-width: var(--width-min);
 }
 
 .page-spacing {


### PR DESCRIPTION
A few high priority tweaks necessary for progressing the mobile experience. Cards from zer0  attached.

Loom explanation of problems and fixes
https://www.loom.com/share/961a4722bee44b23bc12762c345896d6

______________
**Fixes**
_Problem 1_
Border radius not applying to the black background for the NFT section in NFT view
https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/d9a42ec6-233b-4960-8761-1363116a5923

_Solution_
Apply border radius to black background
______________

_Problem 2_
UX was confusing navigating between domains because navigating domains would keep you at the bottom of the list, rather than scrolling up to the preview of the NFT you just clicked
https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/b31292c8-58b1-4e17-a6c9-a3c4a9695fa1

_Solution_
Scroll to the top of the window on domain changes, or on navigation to NFT view.
______________

_Problem 3_
Difficult to exit NFT lightboxes - sometimes clicking overlay does nothing
https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/fd85a05f-a335-4e8a-9318-1f9758f601ea

_Solution_
Added a close button in the top right corner for all overlays.
______________

_Problem 4_
About button is getting pushed beyond the nav bar when the content to the left is very wide.
https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/39aef5b9-f9b5-4e40-9467-804ff16f7daa

_Solution_
Removed the search input on smaller breakpoints - it would need to be **very** small to fit, which wouldn't be a good UX. We should add a button for opening the search on mobile.