### PR TITLE
Switch Fathom from Auto to Hash

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,7 +43,7 @@
 
 		<script
 			src="https://parrotfish.wilderworld.com/script.js"
-			data-spa="auto"
+			data-spa="hash"
 			data-site="ZZNCORJZ"
 			defer
 		></script>


### PR DESCRIPTION
Switches Fathom Integration to force hash based routing instead of enabling auto-detection. This will allow us to see visits and users for specific namespaces on Fathom.