### PR TITLE
Better auction countdown banner

### DIFF
--- a/src/components/Banners/CountdownBanner/CountdownBanner.module.css
+++ b/src/components/Banners/CountdownBanner/CountdownBanner.module.css
@@ -69,7 +69,7 @@
 }
 
 .Remaining {
-	margin-left: 0px;
+	margin-left: 4px;
 }
 
 .Bid {

--- a/src/components/Banners/CountdownBanner/CountdownBanner.tsx
+++ b/src/components/Banners/CountdownBanner/CountdownBanner.tsx
@@ -7,8 +7,11 @@ import styles from './CountdownBanner.module.css';
 import arrow from './assets/bidarrow.svg';
 
 import CountdownData from './countdown.json';
-// "startTimeUTC": 1632574800000,
-// "endTimeUTC": 1632657600000,
+
+const startTimeUTC = new Date().getTime() + 15000;
+const endTimeUTC = new Date().getTime() + 30000;
+const preHoursVisible = 0.003;
+const postHoursVisible = 0.003;
 
 const CountdownBanner = () => {
 	//////////////////
@@ -32,8 +35,8 @@ const CountdownBanner = () => {
 	>();
 
 	// Grab start and end from JSON file
-	const startTime = CountdownData.startTimeUTC;
-	const endTime = CountdownData.endTimeUTC;
+	const startTime = startTimeUTC;
+	const endTime = endTimeUTC;
 
 	// Had to break the flow of the file for this to be used below
 	const hoursToMilliseconds = (hrs: number) => {
@@ -41,10 +44,8 @@ const CountdownBanner = () => {
 	};
 
 	// Calculated times from JSON file
-	const preStartTime =
-		startTime - hoursToMilliseconds(CountdownData.pre.hoursVisible);
-	const postEndTime =
-		endTime + hoursToMilliseconds(CountdownData.after.hoursVisible);
+	const preStartTime = startTime - hoursToMilliseconds(preHoursVisible);
+	const postEndTime = endTime + hoursToMilliseconds(postHoursVisible);
 
 	///////////////
 	// Functions //
@@ -133,7 +134,10 @@ const CountdownBanner = () => {
 			onClick={onClick}
 			className={`${styles.nextDrop} border-rounded`}
 		>
-			{text} {timeRemainingLabel && timeRemainingLabel}
+			{text}{' '}
+			{timeRemainingLabel && (
+				<b className={styles.Remaining}>{timeRemainingLabel}</b>
+			)}
 			{buttonText && (
 				<b className={styles.Bid}>
 					{buttonText}

--- a/src/components/Banners/CountdownBanner/CountdownBanner.tsx
+++ b/src/components/Banners/CountdownBanner/CountdownBanner.tsx
@@ -8,11 +8,6 @@ import arrow from './assets/bidarrow.svg';
 
 import CountdownData from './countdown.json';
 
-const startTimeUTC = new Date().getTime() + 15000;
-const endTimeUTC = new Date().getTime() + 30000;
-const preHoursVisible = 0.003;
-const postHoursVisible = 0.003;
-
 const CountdownBanner = () => {
 	//////////////////
 	// State & Data //
@@ -35,8 +30,8 @@ const CountdownBanner = () => {
 	>();
 
 	// Grab start and end from JSON file
-	const startTime = startTimeUTC;
-	const endTime = endTimeUTC;
+	const startTime = CountdownData.startTimeUTC;
+	const endTime = CountdownData.endTimeUTC;
 
 	// Had to break the flow of the file for this to be used below
 	const hoursToMilliseconds = (hrs: number) => {
@@ -44,8 +39,10 @@ const CountdownBanner = () => {
 	};
 
 	// Calculated times from JSON file
-	const preStartTime = startTime - hoursToMilliseconds(preHoursVisible);
-	const postEndTime = endTime + hoursToMilliseconds(postHoursVisible);
+	const preStartTime =
+		startTime - hoursToMilliseconds(CountdownData.pre.hoursVisible);
+	const postEndTime =
+		endTime + hoursToMilliseconds(CountdownData.after.hoursVisible);
 
 	///////////////
 	// Functions //

--- a/src/components/Banners/CountdownBanner/countdown.json
+++ b/src/components/Banners/CountdownBanner/countdown.json
@@ -1,0 +1,18 @@
+{
+	"domain": "guild.knight.guidance",
+	"startTimeUTC": 1632621600000,
+	"endTimeUTC": 1632708000000,
+	"pre": {
+		"label": "Chad Knight auction starting in",
+		"hoursVisible": 12
+	},
+	"during": {
+		"label": "Chad Knight auction closing in",
+		"button": "Bid Now"
+	},
+	"after": {
+		"label": "Chad Knight auction has closed",
+		"button": "View",
+		"hoursVisible": 3
+	}
+}

--- a/src/components/Banners/CountdownBanner/countdown.json
+++ b/src/components/Banners/CountdownBanner/countdown.json
@@ -1,7 +1,7 @@
 {
 	"domain": "guild.knight.guidance",
-	"startTimeUTC": 1632621600000,
-	"endTimeUTC": 1632708000000,
+	"startTimeUTC": 1632618000000,
+	"endTimeUTC": 1632704400000,
 	"pre": {
 		"label": "Auction for Wild Guidance will start at 6pm PST -",
 		"hoursVisible": 12

--- a/src/components/Banners/CountdownBanner/countdown.json
+++ b/src/components/Banners/CountdownBanner/countdown.json
@@ -3,16 +3,16 @@
 	"startTimeUTC": 1632621600000,
 	"endTimeUTC": 1632708000000,
 	"pre": {
-		"label": "Chad Knight auction starting in",
+		"label": "Auction for Wild Guidance will start at 6pm PST -",
 		"hoursVisible": 12
 	},
 	"during": {
-		"label": "Chad Knight auction closing in",
+		"label": "Wild Guidance bidding ends in",
 		"button": "Bid Now"
 	},
 	"after": {
-		"label": "Chad Knight auction has closed",
-		"button": "View",
+		"label": "Bidding for Wild Guidance has ended",
+		"button": "View Results",
 		"hoursVisible": 3
 	}
 }

--- a/src/containers/Tables/SubdomainTable/SubdomainTable.tsx
+++ b/src/containers/Tables/SubdomainTable/SubdomainTable.tsx
@@ -43,7 +43,6 @@ const SubdomainTable = (props: SubdomainTableProps) => {
 				infiniteScroll
 				isLoading={loading}
 				loadingText={'Loading Subdomains'}
-				style={props.style}
 			/>
 		</>
 	);

--- a/src/pages/ZNS/ZNS.tsx
+++ b/src/pages/ZNS/ZNS.tsx
@@ -29,6 +29,7 @@ import {
 	TitleBar,
 	Tooltip,
 	IconButton,
+	CountdownBanner,
 	Overlay,
 	Profile,
 	NotificationDrawer,
@@ -280,12 +281,13 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 		let to;
 		if (isVisible && previewCardRef) {
 			// If should be visible, slide down
-			to = { opacity: 1, marginTop: 0 };
+			to = { opacity: 1, marginTop: 0, marginBottom: 16 };
 		} else if (domain === '/') {
 			// If root view, slide up
 			to = {
 				opacity: 0,
-				marginTop: -(previewCardRef?.current?.clientHeight || 0) - 8,
+				marginTop: -(previewCardRef?.current?.clientHeight || 0) - 12,
+				marginBottom: 16,
 			};
 		} else {
 			// If NFT view, don't render
@@ -498,6 +500,8 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 				</FilterBar>
 
 				{previewCard()}
+
+				<CountdownBanner />
 
 				{showDomainTable && subTable}
 


### PR DESCRIPTION
Set up a nicer auction countdown timer. Still not the ideal solution we're after, but a much nicer iteration.

**Changes**
Added pre and post messaging - "auction starting in x", "auction ended". You can set an amount of time for these messages to be visible for, so auction start countdown starts 12 hours before the auction, and the auction end message disappears after 3 hours.

Set up values for next drop - may need changing
