### PR TITLE
Client-side enforcement of lowercase domain names in Mint flow

### DIFF
--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -27,6 +27,8 @@ type TextInputProps = {
 	resizable?: boolean;
 	alphanumeric?: boolean; // If we want only alphanumeric characters
 	numeric?: boolean;
+	lowercase?: boolean;
+	maxLength?: number;
 };
 
 const TextInput: React.FC<TextInputProps> = ({
@@ -42,6 +44,8 @@ const TextInput: React.FC<TextInputProps> = ({
 	resizable,
 	alphanumeric,
 	numeric,
+	lowercase,
+	maxLength,
 }) => {
 	//////////////////
 	// State & Data //
@@ -55,10 +59,20 @@ const TextInput: React.FC<TextInputProps> = ({
 
 	const handleChange = (event: any) => {
 		const newValue = event.target.value;
-		if (validate(newValue) && onChange) return onChange(event.target.value);
+		if (validate(newValue) && onChange) {
+			return onChange(format(event.target.value));
+		}
+	};
+
+	const format = (str: string) => {
+		if (lowercase) {
+			return str.toLowerCase();
+		}
+		return str;
 	};
 
 	const validate = (str: string) => {
+		if (maxLength && maxLength < str.length) return false;
 		if (alphanumeric && !isAlphanumeric(str)) return false;
 		if (numeric && !isNumber(str)) return false;
 		return true;

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -11,41 +11,38 @@ import styles from './TextInput.module.css';
 //- Local Imports
 import { isAlphanumeric, isNumber } from './validation';
 
-// TODO: Implement max characters (props.max)
-// TODO: Convert to TypeScript
-
 type TextInputProps = {
+	alphanumeric?: boolean; // No symbols
 	autosize?: boolean;
-	onChange: (text: string) => void;
 	error?: boolean;
 	errorText?: string;
-	placeholder?: string;
-	type?: string;
-	text?: string;
-	multiline?: boolean;
-	style?: React.CSSProperties;
-	resizable?: boolean;
-	alphanumeric?: boolean; // If we want only alphanumeric characters
-	numeric?: boolean;
-	lowercase?: boolean;
+	lowercase?: boolean; // Lowercase only
 	maxLength?: number;
+	multiline?: boolean;
+	numeric?: boolean; // Numbers only
+	onChange: (text: string) => void;
+	placeholder?: string;
+	resizable?: boolean;
+	style?: React.CSSProperties;
+	text?: string;
+	type?: string;
 };
 
 const TextInput: React.FC<TextInputProps> = ({
+	alphanumeric,
 	autosize,
-	onChange,
 	error,
 	errorText,
-	placeholder,
-	type,
-	text,
-	multiline,
-	style,
-	resizable,
-	alphanumeric,
-	numeric,
 	lowercase,
 	maxLength,
+	multiline,
+	numeric,
+	onChange,
+	placeholder,
+	resizable,
+	style,
+	text,
+	type,
 }) => {
 	//////////////////
 	// State & Data //

--- a/src/containers/MintNewNFT/MintNewNFT.tsx
+++ b/src/containers/MintNewNFT/MintNewNFT.tsx
@@ -155,6 +155,17 @@ const MintNewNFT: React.FC<MintNewNFTProps> = ({
 		}
 	};
 
+	const checkIsNftValid = () => {
+		let valid = true;
+		// Domain name lowercase
+		if (!account || !tokenInformation) {
+			valid = false;
+		} else if (/[A-Z]/.test(tokenInformation.domain)) {
+			valid = false;
+		}
+		return valid;
+	};
+
 	// Sets the token stake data from the token stake section
 	const getTokenStake = (data: TokenStakeType) => {
 		setTokenStake(data);
@@ -237,6 +248,12 @@ const MintNewNFT: React.FC<MintNewNFTProps> = ({
 
 	// Start submit process - call function for minting or requesting
 	const submit = () => {
+		const isNftValid = checkIsNftValid();
+		// if (!isNftValid) {
+		// 	setError('Something went wrong - please try again');
+		// 	return;
+		// }
+
 		setIsMintLoading(true);
 
 		const doSubmit = async () => {

--- a/src/containers/MintNewNFT/MintNewNFT.tsx
+++ b/src/containers/MintNewNFT/MintNewNFT.tsx
@@ -249,10 +249,10 @@ const MintNewNFT: React.FC<MintNewNFTProps> = ({
 	// Start submit process - call function for minting or requesting
 	const submit = () => {
 		const isNftValid = checkIsNftValid();
-		// if (!isNftValid) {
-		// 	setError('Something went wrong - please try again');
-		// 	return;
-		// }
+		if (!isNftValid) {
+			setError('Something went wrong - please try again');
+			return;
+		}
 
 		setIsMintLoading(true);
 

--- a/src/containers/MintNewNFT/sections/TokenInformation.tsx
+++ b/src/containers/MintNewNFT/sections/TokenInformation.tsx
@@ -97,13 +97,24 @@ const TokenInformation: React.FC<TokenInformationProps> = ({
 	const pressContinue = () => {
 		// Field Validation
 		const errors: Error[] = [];
-		if (!name.length) errors.push({ id: 'name', text: 'NFT name is required' });
-		if (!story.length) errors.push({ id: 'story', text: 'Story is required' });
-		if (!image.length) errors.push({ id: 'image', text: 'Media is required' });
-		if (!domain.length)
+		if (!name.length) {
+			errors.push({ id: 'name', text: 'NFT name is required' });
+		}
+		if (!story.length) {
+			errors.push({ id: 'story', text: 'Story is required' });
+		}
+		if (!image.length) {
+			errors.push({ id: 'image', text: 'Media is required' });
+		}
+		if (!domain.length) {
 			errors.push({ id: 'domain', text: 'Domain name is required' });
-		if (existingSubdomains.includes(domain))
+		}
+		if (/[A-Z]/.test(domain)) {
+			errors.push({ id: 'domain', text: 'Domain name must be lower case' });
+		}
+		if (existingSubdomains.includes(domain)) {
 			errors.push({ id: 'domain', text: 'Domain name already exists' });
+		}
 
 		// Don't continue if there's errors
 		if (errors.length) return setErrors(errors);
@@ -127,6 +138,20 @@ const TokenInformation: React.FC<TokenInformationProps> = ({
 	useEffect(() => {
 		if (onResize) onResize();
 	}, [errors, story]);
+
+	useEffect(() => {
+		// @todo refactor
+		if (/[A-Z]/.test(domain)) {
+			setErrors([
+				...errors,
+				{ id: 'domain', text: 'Domain name must be lower case' },
+			]);
+		} else {
+			setErrors(
+				errors.filter((e) => e.text !== 'Domain name must be lower case'),
+			);
+		}
+	}, [domain]);
 
 	////////////
 	// Render //
@@ -179,6 +204,7 @@ const TokenInformation: React.FC<TokenInformationProps> = ({
 							error={hasError('domain')}
 							errorText={errorText('domain')}
 							alphanumeric
+							maxLength={25}
 						/>
 						{/* <ToggleButton
 							toggled={locked}

--- a/src/lib/providers/MintProvider.tsx
+++ b/src/lib/providers/MintProvider.tsx
@@ -58,7 +58,7 @@ const MintProvider: React.FC<MintProviderType> = ({ children }) => {
 	const mint = async (nft: NftParams, setStatus: (status: string) => void) => {
 		// @todo better validation
 		if (/[A-Z]/.test(nft.zna)) {
-			return;
+			throw Error(`Invalid domain name: ${nft.zna} (Uppercase characters)`);
 		}
 
 		let tx: Maybe<ethers.ContractTransaction>;

--- a/src/lib/providers/MintProvider.tsx
+++ b/src/lib/providers/MintProvider.tsx
@@ -56,6 +56,11 @@ const MintProvider: React.FC<MintProviderType> = ({ children }) => {
 	// }, []);
 
 	const mint = async (nft: NftParams, setStatus: (status: string) => void) => {
+		// @todo better validation
+		if (/[A-Z]/.test(nft.zna)) {
+			return;
+		}
+
 		let tx: Maybe<ethers.ContractTransaction>;
 
 		// get metadata uri

--- a/src/lib/providers/StakingRequestProvider.tsx
+++ b/src/lib/providers/StakingRequestProvider.tsx
@@ -117,7 +117,9 @@ const StakingRequestProvider: React.FC<StakingRequestProviderType> = ({
 	) => {
 		// @todo better validation
 		if (/[A-Z]/.test(params.nft.domain)) {
-			return;
+			throw Error(
+				`Invalid domain name: ${params.nft.domain} (Uppercase characters)`,
+			);
 		}
 
 		setStatus(`Uploading metadata`);

--- a/src/lib/providers/StakingRequestProvider.tsx
+++ b/src/lib/providers/StakingRequestProvider.tsx
@@ -115,6 +115,11 @@ const StakingRequestProvider: React.FC<StakingRequestProviderType> = ({
 		params: StakingRequest,
 		setStatus: (status: string) => void,
 	) => {
+		// @todo better validation
+		if (/[A-Z]/.test(params.nft.domain)) {
+			return;
+		}
+
 		setStatus(`Uploading metadata`);
 
 		let metadata: Maybe<UploadedDomainMetadata>;


### PR DESCRIPTION
All domain names need to be lower case. This PR adds validation to prevent transactions happening if someone inputs a lowercase domain in the Mint flow.

Validation:
1. In the Information section of the Mint flow (i.e. page 1) - you can't continue with the flow if the domain has an uppercase character.
2. A check in the final submit method of the Mint flow, just in case the first bit of validation failed, or in case someone is trying to circumvent the first step.
3. An extra check in the Mint & Staking providers - this one should never be hit, but probably wise to have it in there.

Note:
In the requirements, it said uppercase characters should be automatically converted to lowercase as they're typed out, but that made the input feel broken. Instead, the dapp renders an error label below the input whenever the domain is invalid.