### PR TITLE
[Bug] Click actions working for elements behind Overlay

### DIFF
--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -30,7 +30,7 @@ const Overlay: React.FC<OverlayProps> = ({
 	nested,
 	fullScreen,
 	style,
-	hasCloseButton,
+	hasCloseButton = true,
 }) => {
 	const [inDOM, setInDOM] = useState<boolean>(false);
 	const [domId, setDomId] = useState('');

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -77,6 +77,7 @@ const Overlay: React.FC<OverlayProps> = ({
 	};
 
 	const closeOverlay = (e: React.MouseEvent) => {
+		e.stopPropagation();
 		const target = e.target as HTMLInputElement;
 		const overlay = document.querySelector(domId);
 		if (

--- a/src/containers/prompts/ConnectWalletPrompt/ConnectWalletPrompt.tsx
+++ b/src/containers/prompts/ConnectWalletPrompt/ConnectWalletPrompt.tsx
@@ -42,7 +42,12 @@ const ConnectWalletPrompt: React.FC<ConnectWalletPromptProps> = ({
 
 	return (
 		<>
-			<Overlay onClose={closeConnectWalletPrompt} centered open={isModalOpen}>
+			<Overlay
+				onClose={closeConnectWalletPrompt}
+				centered
+				open={isModalOpen}
+				hasCloseButton={false}
+			>
 				<Confirmation
 					title={'Connect your Wallet'}
 					confirmText={'Connect'}


### PR DESCRIPTION
Summary: We've a couple of bugs in the Overlay component and we're fixing them as part of this PR.
- Prevent click actions on elements behind overlay when an overlay is active
- Put the close icon behind a config property.

Task URL: https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/ee34564b-25c7-46e6-90c2-e9b1c043de58