### PR TITLE
fix(overlay): issue with background visibility for overlay in firefox

### DIFF
--- a/src/components/Cards/PreviewCard/PreviewCard.module.css
+++ b/src/components/Cards/PreviewCard/PreviewCard.module.css
@@ -7,7 +7,7 @@
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-	background: var(--background-blue-card-wilder);
+	background: var(--background-blue-card-wilder) !important;
 }
 /* marginTop: 16, marginLeft: 43, marginRight: 43, marginBottom: 0 */
 .PreviewCard hr {

--- a/src/components/Overlay/Overlay.module.css
+++ b/src/components/Overlay/Overlay.module.css
@@ -16,7 +16,7 @@
 	z-index: 9000;
 	opacity: 0;
 
-	background: rgba(0, 0, 0, 0.9);
+	background: rgba(0, 0, 0, 0.9) !important;
 	transition: backdrop-filter 0.2s;
 }
 


### PR DESCRIPTION
**Summary**: 
Overlay backdrop isn't taking up the full screen

The issue is due to the following polyfill styles in `main.css`

```
/*
 *
 * Polyfills
 *
 */

@supports not (
	(-webkit-backdrop-filter: blur(20em)) or (backdrop-filter: blur(2em))
) {
	.blur {
		background: rgba(78, 0, 132, 0.4) !important;
	}

	.overlay {
		background: rgba(0, 0, 0, 0.4) !important;
	}
}
```
In firefox the above polyfill kicks in and causes the overlay to have a different opacity due to `!important`.

**Task URL**:
https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/3f2927e7-4103-49ce-8efb-745b78a31aed
