### PR TITLE
Handle new NFT image URLs

### DIFF
--- a/src/components/NFTMedia/index.tsx
+++ b/src/components/NFTMedia/index.tsx
@@ -91,9 +91,9 @@ const NFTMediaContainer = (props: MediaContainerProps) => {
 	// Gets MIME type of media at URL
 	// Useful because our IPFS links don't have
 	// a file extension
-	const checkMediaType = () => {
+	const checkMediaType = (hash: string) => {
 		return new Promise((resolve, reject) => {
-			fetch(ipfsUrl, { method: 'HEAD' })
+			fetch('https://ipfs.fleek.co/ipfs/' + hash, { method: 'HEAD' })
 				.then((r: Response) => {
 					const contentTypeHeader = r.headers.get('Content-Type');
 
@@ -113,8 +113,8 @@ const NFTMediaContainer = (props: MediaContainerProps) => {
 
 	// Gets data for media
 	const getMediaData = async () => {
-		const mediaType = (await checkMediaType()) as MediaType;
 		const hash = getHashFromIPFSUrl(ipfsUrl);
+		const mediaType = (await checkMediaType(hash)) as MediaType;
 		if (isMounted.current) {
 			setMediaType(mediaType);
 			setMediaLocation(hash);

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -14,7 +14,12 @@ export async function getMetadata(
 			return memoryCache[metadataUrl];
 		}
 
-		const response = await fetch(metadataUrl);
+		let requestUrl = metadataUrl;
+		if (metadataUrl.startsWith('ipfs://')) {
+			requestUrl = 'https://ipfs.fleek.co/ipfs/' + metadataUrl.slice(7);
+		}
+
+		const response = await fetch(requestUrl);
 		const data = await response.json();
 		const metadata = {
 			title: data.name || data.title,


### PR DESCRIPTION
**What this is**
We're switching the metadata of our NFTs slightly. Images will now be stored at `ipfs://[hash]` instead of `https://ipfs.fleek.co/ipfs/[hash]`. We need to handle both of these cases in the dapp.

**Solution**
Added a case to our "get hash from URL" method in the NFTMedia container which handles `ipfs://[hash]` URLs.