### PR TITLE
Handle new NFT image URLs

### DIFF
--- a/src/components/NFTMedia/index.tsx
+++ b/src/components/NFTMedia/index.tsx
@@ -53,11 +53,19 @@ const NFTMediaContainer = (props: MediaContainerProps) => {
 
 	// Pulls the IPFS hash from an IPFS url
 	// https://ipfs.fleek.co/ipfs/QmNr4mi2T4Qm5ErtnSdxA7a5nCPT2YkF5gAPnLm8oSCXY8
+	// or
+	// ipfs://QmNr4mi2T4Qm5ErtnSdxA7a5nCPT2YkF5gAPnLm8oSCXY8
 	// turns into
 	// QmNr4mi2T4Qm5ErtnSdxA7a5nCPT2YkF5gAPnLm8oSCXY8
 	const getHashFromIPFSUrl = (url: string) => {
-		const hashIndex = url.lastIndexOf('/') + 1;
-		return url.slice(hashIndex);
+		if (url.startsWith('ipfs://')) {
+			// ipfs://
+			return url.slice(7);
+		} else {
+			// http(s)://
+			const hashIndex = url.lastIndexOf('/') + 1;
+			return url.slice(hashIndex);
+		}
 	};
 
 	// Sets internal "media loading" state
@@ -83,9 +91,9 @@ const NFTMediaContainer = (props: MediaContainerProps) => {
 	// Gets MIME type of media at URL
 	// Useful because our IPFS links don't have
 	// a file extension
-	const checkMediaType = () => {
+	const checkMediaType = (hash: string) => {
 		return new Promise((resolve, reject) => {
-			fetch(ipfsUrl, { method: 'HEAD' })
+			fetch('https://ipfs.fleek.co/ipfs/' + hash, { method: 'HEAD' })
 				.then((r: Response) => {
 					const contentTypeHeader = r.headers.get('Content-Type');
 
@@ -105,8 +113,8 @@ const NFTMediaContainer = (props: MediaContainerProps) => {
 
 	// Gets data for media
 	const getMediaData = async () => {
-		const mediaType = (await checkMediaType()) as MediaType;
 		const hash = getHashFromIPFSUrl(ipfsUrl);
+		const mediaType = (await checkMediaType(hash)) as MediaType;
 		if (isMounted.current) {
 			setMediaType(mediaType);
 			setMediaLocation(hash);
@@ -183,7 +191,7 @@ const NFTMediaContainer = (props: MediaContainerProps) => {
 			return (
 				<IPFSMedia
 					alt={alt}
-					ipfsUrl={ipfsUrl!}
+					ipfsUrl={'https://ipfs.fleek.co/ipfs/' + mediaLocation!}
 					onClick={toggleLightbox}
 					onLoad={onLoadMedia}
 					size={matchSize ? size : undefined}

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -14,7 +14,12 @@ export async function getMetadata(
 			return memoryCache[metadataUrl];
 		}
 
-		const response = await fetch(metadataUrl);
+		let requestUrl = metadataUrl;
+		if (metadataUrl.startsWith('ipfs://')) {
+			requestUrl = 'https://ipfs.fleek.co/ipfs/' + metadataUrl.slice(7);
+		}
+
+		const response = await fetch(requestUrl);
 		const data = await response.json();
 		const metadata = {
 			title: data.name || data.title,


### PR DESCRIPTION
What this is
We're switching the metadata of our NFTs slightly. Images will now be stored at ipfs://[hash] instead of https://ipfs.fleek.co/ipfs/[hash]. We need to handle both of these cases in the dapp.

Solution
Added a case to our "get hash from URL" method in the NFTMedia container which handles ipfs://[hash] URLs.