### PR TITLE
feat(nft-view): remove scroll in history view and height limitation

### DIFF
--- a/src/containers/other/NFTView/NFTView.module.css
+++ b/src/containers/other/NFTView/NFTView.module.css
@@ -253,7 +253,7 @@
 }
 
 .History ul {
-	padding: 0 20px 20px 20px;
+	padding: 0 20px;
 }
 
 .History span {


### PR DESCRIPTION
**Summary**: 
Having a scroll region in the history can make for a frustrating UX as you are caught in it when trying to scroll the page
* Remove scroll region
* Display all history items by removing height limitation of history container

**Task URL**:
https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/163eec0c-806b-49c6-bb08-3a8471879cb0

