### PR TITLE
Fix for incorrect file on asset download

### DIFF
--- a/src/containers/other/NFTView/NFTView.module.scss
+++ b/src/containers/other/NFTView/NFTView.module.scss
@@ -94,6 +94,7 @@
 		align-items: center;
 		width: 56px;
 		height: 37px;
+		padding-top: 0;
 
 		background: none;
 

--- a/src/containers/other/NFTView/NFTView.tsx
+++ b/src/containers/other/NFTView/NFTView.tsx
@@ -145,14 +145,16 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 				}
 				fetch(asset, {
 					method: 'GET',
-					headers: {},
 				})
 					.then((response) => {
 						response.arrayBuffer().then(function (buffer) {
 							const url = window.URL.createObjectURL(new Blob([buffer]));
 							const link = document.createElement('a');
 							link.href = url;
-							link.setAttribute('download', hash + '.png'); // not sure why png works for all types
+							link.setAttribute(
+								'download',
+								asset.split('/')[asset.split('/').length - 1],
+							);
 							document.body.appendChild(link);
 							link.click();
 							link.remove();

--- a/src/containers/other/NFTView/NFTView.tsx
+++ b/src/containers/other/NFTView/NFTView.tsx
@@ -143,6 +143,7 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 				if (typeof asset !== 'string') {
 					return;
 				}
+				addNotification('Download starting');
 				fetch(asset, {
 					method: 'GET',
 				})


### PR DESCRIPTION
Fixed a bug where the download button would always download the asset as a png