### PR TITLE
Fix missing bids in NFT View History

### DIFF
--- a/src/containers/other/NFTView/NFTView.tsx
+++ b/src/containers/other/NFTView/NFTView.tsx
@@ -193,33 +193,20 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 
 	const getHistory = async () => {
 		if (znsDomain.domain) {
-			const events = await sdk.instance?.getDomainEvents(znsDomain.domain.id);
-
-			const bids = await sdk.getBids(znsDomain.domain.id);
-			if (!events || !events.length) {
-				setAllItems([]);
-				return;
-			}
-
 			try {
-				const sorted = events.sort(
-					(a, b) =>
-						new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
-				);
-				let filter: DomainEvent[] = [];
-				//removes repeated timestamps of the sorted array, sdk must fix this later
-				sorted.reverse().reduce(function (prev, current) {
-					if (prev.timestamp !== current.timestamp) filter.push(current);
-					return current;
-				});
+				const events = await sdk.instance?.getDomainEvents(znsDomain.domain.id);
 
-				const sortedBids = bids?.sort(
-					(a, b) => Number(b.amount) - Number(a.amount),
-				);
+				const bids = events.filter((e) => e.type === 2) as DomainBidEvent[];
+				const highest = bids.sort((a, b) => {
+					return (
+						Number(ethers.utils.formatEther(b.amount)) -
+						Number(ethers.utils.formatEther(a.amount))
+					);
+				})[0];
 
 				if (!isMounted.current) return;
-				setAllItems(filter);
-				setHighestBid(sortedBids?.[0]);
+				setAllItems(events);
+				setHighestBid(highest);
 			} catch (e) {
 				console.error('Failed to retrieve bid data');
 			}
@@ -310,9 +297,9 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 				<div className={styles.Price}>
 					<h2>Highest Bid</h2>
 					<span className={styles.Crypto}>
-						{Number(ethers.utils.formatEther(highestBid.amount))
-							.toFixed(2)
-							.toLocaleString()}{' '}
+						{Number(
+							ethers.utils.formatEther(highestBid.amount!),
+						).toLocaleString()}{' '}
 						WILD{' '}
 						{highestBidUsd !== undefined && wildPriceUsd > 0 && (
 							<span className={styles.Fiat}>(${toFiat(highestBidUsd)})</span>


### PR DESCRIPTION
**Bug**

As per images below, some bids were missing from the bid history but were still being calculated in the "Highest Bid" calculation. I fixed this by removing all zAuction API calls and only grabbing NFT event data through the SDK.

**Bug Report**

![rnjfks0jtcfoddeixb4s](https://user-images.githubusercontent.com/12437916/138390434-11e7d9f5-e129-43ee-a472-60fafe1be4f4.png)
![srzv5ruyplqopnliqmbw](https://user-images.githubusercontent.com/12437916/138390364-d5a56e5b-996d-48df-bcdd-910d5b73dbf4.png)
![ot9i8hstxxlimfizb1jz](https://user-images.githubusercontent.com/12437916/138390369-bb91ff34-0d00-4bb6-bfb2-ac71be4af069.png)

