### PR TITLE
Fix border radius not applying to children of main table container on mobile

### DIFF
--- a/src/components/Cards/PreviewCard/PreviewCard.module.scss
+++ b/src/components/Cards/PreviewCard/PreviewCard.module.scss
@@ -7,7 +7,6 @@
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-	background: var(--background-blue-card-wilder) !important;
 }
 /* marginTop: 16, marginLeft: 43, marginRight: 43, marginBottom: 0 */
 .PreviewCard hr {

--- a/src/components/Tables/GenericTable/GenericTable.module.scss
+++ b/src/components/Tables/GenericTable/GenericTable.module.scss
@@ -1,7 +1,6 @@
 .Container {
 	position: relative;
 	width: 100%;
-	background: var(--background-purple-card-20);
 	transition: height var(--animation-time-medium) ease;
 }
 


### PR DESCRIPTION
https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/03f1086a-af92-4ef5-bff7-35769ac523f3

**Problem**
![image](https://user-images.githubusercontent.com/12437916/138814413-b17696b3-6299-4000-b62e-13ad730df5c5.png)

As per image above, the rounded borders of the main container aren't applying to its children.

**Solution**
Removed background of `GenericTable` and `PreviewCard`. It makes more sense architecturally for these components to not define their own backgrounds, as they can be rendered in many different contexts.