### PR TITLE
fix: removed backgrounds from generic components

### DIFF
--- a/src/components/Cards/PreviewCard/PreviewCard.module.scss
+++ b/src/components/Cards/PreviewCard/PreviewCard.module.scss
@@ -7,7 +7,6 @@
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-	background: var(--background-blue-card-wilder) !important;
 }
 /* marginTop: 16, marginLeft: 43, marginRight: 43, marginBottom: 0 */
 .PreviewCard hr {

--- a/src/components/Tables/GenericTable/GenericTable.module.scss
+++ b/src/components/Tables/GenericTable/GenericTable.module.scss
@@ -1,7 +1,6 @@
 .Container {
 	position: relative;
 	width: 100%;
-	background: var(--background-purple-card-20);
 	transition: height var(--animation-time-medium) ease;
 }
 


### PR DESCRIPTION
PreviewCard and GenericTable shouldn't have their backgrounds defined on the component level
Background of the main section should be defined by the main section