### PR TITLE
Handle domains with >1k subdomains

### DIFF
--- a/src/components/Banners/CountdownBanner/CountdownBanner.tsx
+++ b/src/components/Banners/CountdownBanner/CountdownBanner.tsx
@@ -71,7 +71,6 @@ const CountdownBanner = () => {
 
 	// Navigates to button link
 	const onClick = () => {
-		console.log('yo');
 		if (buttonLink) {
 			history.push(buttonLink);
 		}

--- a/src/containers/Tables/SubdomainTable/SubdomainTable.tsx
+++ b/src/containers/Tables/SubdomainTable/SubdomainTable.tsx
@@ -59,10 +59,12 @@ const SubdomainTable = (props: SubdomainTableProps) => {
 					setData(subDomainsData);
 				}
 			} catch (err) {
-				console.log(err);
+				console.error(err);
 			}
 
-			setAreDomainMetricsLoading(false);
+			if (isMounted) {
+				setAreDomainMetricsLoading(false);
+			}
 		} else {
 			setData([]);
 			setLoadingDomain(domain?.name);

--- a/src/containers/flows/WheelsRaffle/RaffleRegistration/RaffleRegistration.tsx
+++ b/src/containers/flows/WheelsRaffle/RaffleRegistration/RaffleRegistration.tsx
@@ -40,7 +40,6 @@ const RaffleRegistration = (props: RaffleRegistrationProps) => {
 
 	const onSubmitEmail = async () => {
 		const valid = isValidEmail(userEmail || '');
-		console.log(valid);
 		if (!valid) {
 			setEmailError('Please enter a valid email address');
 		} else {

--- a/src/containers/other/NFTView/NFTView.tsx
+++ b/src/containers/other/NFTView/NFTView.tsx
@@ -174,7 +174,7 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 						});
 					})
 					.catch((err) => {
-						console.log(err);
+						console.error(err);
 					});
 			} catch (e) {
 				console.error(e);
@@ -279,11 +279,7 @@ const NFTView: React.FC<NFTViewProps> = ({ domain, onTransfer }) => {
 
 	useEffect(() => {
 		if (!isMounted.current) return;
-		if (
-			znsDomain.domain &&
-			znsDomain.domain.metadata &&
-			!znsDomain.domain.image
-		) {
+		if (znsDomain.domain) {
 			if (!isMounted.current) return;
 
 			setIsOwnedByYou(

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -75,7 +75,7 @@ export const createDomainMetadata = async (params: DomainMetadataParams) => {
 
 		return uploadedMetadata;
 	} catch (e) {
-		console.log(e);
+		console.error(e);
 		throw Error(e);
 	}
 };

--- a/src/pages/ZNS/ZNS.tsx
+++ b/src/pages/ZNS/ZNS.tsx
@@ -115,7 +115,6 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 	React.useEffect(() => {
 		if (!loading) {
 			if (!znsDomain) {
-				console.log(`invalid domain, returning to home`);
 				history.push('/');
 				return;
 			}


### PR DESCRIPTION
**Problem**
With our old system, the dapp could pull max 1000 subdomains. Wheels drop 2 will see 10k subdomains in one domain, so we need to extend this functionality.

**Solution**
Temporary: use SDK for domains with >10k subdomains. This will be slow on first load, decent speed when loading from cache. This will need to be improved later.