### PR TITLE
Fix navigation bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zns-dapp",
-	"version": "0.10.9",
+	"version": "0.10.11",
 	"private": true,
 	"dependencies": {
 		"@apollo/client": "^3.3.13",


### PR DESCRIPTION
**Problem**
Navigating to a domain which you have already loaded would make the subdomain table fail to load. 

**Solution**
Switched current domain vs loading domain tracking to a ref, rather than a state object.