### PR TITLE
Disable button grow on list tables

### DIFF
--- a/src/components/Tables/DomainTable/DomainTable.module.scss
+++ b/src/components/Tables/DomainTable/DomainTable.module.scss
@@ -96,14 +96,12 @@
 	background: var(--color-background-alt-50);
 }
 
-.DomainTable > tbody > tr img,
-.DomainTable > tbody > tr button {
+.DomainTable > tbody > tr img {
 	transition: transform var(--animation-time-medium) ease-in-out;
 }
 
 .DomainTable > tbody > tr:hover img,
-.DomainTable > tbody > tr:hover video,
-.DomainTable > tbody > tr:hover button {
+.DomainTable > tbody > tr:hover video {
 	transform: scale(1.1);
 }
 

--- a/src/components/Tables/RequestTable/RequestTable.module.scss
+++ b/src/components/Tables/RequestTable/RequestTable.module.scss
@@ -81,13 +81,11 @@
 	background: var(--background-purple-card-20);
 }
 
-.RequestTable > tbody > tr img,
-.RequestTable > tbody > tr button {
+.RequestTable > tbody > tr img {
 	transition: transform var(--animation-time-medium) ease-in-out;
 }
 
-.RequestTable > tbody > tr:hover > td > img,
-.RequestTable > tbody > tr:hover button {
+.RequestTable > tbody > tr:hover > td > img {
 	transform: scale(1.1);
 }
 


### PR DESCRIPTION
Link to associated zer0 card:  
https://zer0.io/a/network/tasks/board/e85a99cf-665f-427c-bb0b-2b4e12ba207a/e0514249-f173-47b1-966d-f8f7e6ff00ed
-----

## 1. Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] zer0 card has been moved to the Code Review column
- [x] zer0 card has a link to this PR
- [x] A reviewer has been tagged in the zer0 card


## 2. PR type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## 3. What is the current behaviour?
Buttons on the list view have a grow animation when you hover it.


## 4. What is the new behaviour?
Disable that geow animation in the list view.


## 5. Other information
