### PR TITLE
Wait for public sale to start before refetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zns-dapp",
-	"version": "0.10.22",
+	"version": "0.10.23",
 	"private": true,
 	"dependencies": {
 		"@apollo/client": "^3.3.13",

--- a/src/containers/flows/MintWheels/index.tsx
+++ b/src/containers/flows/MintWheels/index.tsx
@@ -299,6 +299,12 @@ const MintWheelsFlowContainer = () => {
 				}
 				const primaryData = d as DropData;
 				if (dropStage !== undefined) {
+					if (hasCountdownFinished && primaryData.dropStage === dropStage) {
+						setTimeout(() => {
+							setRefetch(refetch + 1);
+						}, 7000);
+						return;
+					}
 					if (primaryData.dropStage === Stage.Upcoming) {
 						setCountdownDate(undefined);
 						setTimeout(() => {

--- a/src/containers/flows/MintWheels/labels.tsx
+++ b/src/containers/flows/MintWheels/labels.tsx
@@ -74,7 +74,7 @@ export const getBannerLabel = (
 		if (countdownDate && isFinished) {
 			timer = (
 				<span style={{ display: 'inline-block', marginTop: 4 }}>
-					Public release starting now
+					Public release starting now - waiting for contract to begin
 				</span>
 			);
 		}


### PR DESCRIPTION
If the countdown ends but the contract hasn't started (for whatever reason), the banner should refetch until the contract is live