### PR TITLE
Add a 'View Bids' button to NFT Grid View in Owned Domains Table

### DIFF
--- a/src/components/Tables/DomainTable/DomainTable.tsx
+++ b/src/components/Tables/DomainTable/DomainTable.tsx
@@ -35,7 +35,7 @@ type DomainTableProps = {
 	isGridView?: boolean;
 	isRootDomain: boolean;
 	onLoad?: () => void;
-	onBtnClick?: (domain: DomainData) => void;
+	onButtonClick?: (domain: DomainData) => void;
 	onRowClick?: (domain: Domain) => void;
 	rowButtonText?: string;
 	// TODO: Find a better way to persist grid view than with props
@@ -60,7 +60,7 @@ const DomainTable: React.FC<DomainTableProps> = ({
 	isGridView,
 	isRootDomain,
 	onLoad,
-	onBtnClick,
+	onButtonClick,
 	onRowClick,
 	rowButtonText,
 	setIsGridView,
@@ -238,11 +238,11 @@ const DomainTable: React.FC<DomainTableProps> = ({
 									Make A Bid
 								</BidButton>
 							)}
-							{!isGlobalTable && onBtnClick && (
+							{!isGlobalTable && onButtonClick && (
 								<ViewBids
 									style={{ marginLeft: 'auto', textTransform: 'uppercase' }}
 									domain={domain}
-									onClick={onBtnClick}
+									onClick={onButtonClick}
 									filterOwnBids={filterOwnBids}
 								/>
 							)}
@@ -301,7 +301,7 @@ const DomainTable: React.FC<DomainTableProps> = ({
 		return (
 			<NFTCardActions
 				domain={domain}
-				onBtnClick={onBtnClick}
+				onButtonClick={onButtonClick}
 				onLoad={checkHeight}
 				filterOwnBids={filterOwnBids}
 			/>

--- a/src/components/Tables/DomainTable/DomainTable.tsx
+++ b/src/components/Tables/DomainTable/DomainTable.tsx
@@ -35,7 +35,7 @@ type DomainTableProps = {
 	isGridView?: boolean;
 	isRootDomain: boolean;
 	onLoad?: () => void;
-	onRowButtonClick?: (domain: DomainData) => void;
+	onBtnClick?: (domain: DomainData) => void;
 	onRowClick?: (domain: Domain) => void;
 	rowButtonText?: string;
 	// TODO: Find a better way to persist grid view than with props
@@ -60,7 +60,7 @@ const DomainTable: React.FC<DomainTableProps> = ({
 	isGridView,
 	isRootDomain,
 	onLoad,
-	onRowButtonClick,
+	onBtnClick,
 	onRowClick,
 	rowButtonText,
 	setIsGridView,
@@ -238,11 +238,11 @@ const DomainTable: React.FC<DomainTableProps> = ({
 									Make A Bid
 								</BidButton>
 							)}
-							{!isGlobalTable && onRowButtonClick && (
+							{!isGlobalTable && onBtnClick && (
 								<ViewBids
 									style={{ marginLeft: 'auto', textTransform: 'uppercase' }}
 									domain={domain}
-									onClick={onRowButtonClick}
+									onClick={onBtnClick}
 									filterOwnBids={filterOwnBids}
 								/>
 							)}
@@ -301,12 +301,9 @@ const DomainTable: React.FC<DomainTableProps> = ({
 		return (
 			<NFTCardActions
 				domain={domain}
-				disableButton={
-					!userId || userId?.toLowerCase() === domain.owner.id.toLowerCase()
-				}
-				hideButton={!isGlobalTable}
-				onButtonClick={buttonClick}
+				onBtnClick={onBtnClick}
 				onLoad={checkHeight}
+				filterOwnBids={filterOwnBids}
 			/>
 		);
 	};

--- a/src/components/Tables/DomainTable/components/NFTCardActions.module.scss
+++ b/src/components/Tables/DomainTable/components/NFTCardActions.module.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-
+	color: var(--color-text-primary);
 	margin-top: 16px;
 }
 

--- a/src/components/Tables/DomainTable/components/NFTCardActions.tsx
+++ b/src/components/Tables/DomainTable/components/NFTCardActions.tsx
@@ -16,14 +16,14 @@ import styles from './NFTCardActions.module.scss';
 type NFTCardActionsProps = {
 	filterOwnBids?: boolean;
 	domain: Domain;
-	onBtnClick?: (domain: DomainData) => void;
+	onButtonClick?: (domain: DomainData) => void;
 	onLoad?: () => void;
 };
 
 const NFTCardActions: React.FC<NFTCardActionsProps> = ({
 	domain,
 	filterOwnBids,
-	onBtnClick,
+	onButtonClick,
 	onLoad,
 }) => {
 	const { getBidsForDomain } = useBidProvider();
@@ -76,11 +76,11 @@ const NFTCardActions: React.FC<NFTCardActionsProps> = ({
 					</>
 				)}
 			</div>
-			{onBtnClick && (
+			{onButtonClick && (
 				<ViewBids
 					style={{ marginLeft: 'auto', textTransform: 'uppercase' }}
 					domain={domain}
-					onClick={onBtnClick}
+					onClick={onButtonClick}
 					filterOwnBids={filterOwnBids}
 				/>
 			)}

--- a/src/components/Tables/DomainTable/components/NFTCardActions.tsx
+++ b/src/components/Tables/DomainTable/components/NFTCardActions.tsx
@@ -3,29 +3,27 @@
 import { useState, useEffect, useRef } from 'react';
 
 // Library Imports
-import { Domain } from 'lib/types';
+import { Domain, DomainData } from 'lib/types';
 import { useBidProvider } from 'lib/providers/BidProvider';
 
 // Component Imports
 import { Spinner } from 'components';
+import ViewBids from './ViewBids';
 
 // Style Imports
 import styles from './NFTCardActions.module.scss';
-import { BidButton } from 'containers';
 
 type NFTCardActionsProps = {
-	disableButton?: boolean;
+	filterOwnBids?: boolean;
 	domain: Domain;
-	hideButton?: boolean;
-	onButtonClick: (domain: Domain) => void;
+	onBtnClick?: (domain: DomainData) => void;
 	onLoad?: () => void;
 };
 
 const NFTCardActions: React.FC<NFTCardActionsProps> = ({
-	disableButton,
 	domain,
-	hideButton,
-	onButtonClick,
+	filterOwnBids,
+	onBtnClick,
 	onLoad,
 }) => {
 	const { getBidsForDomain } = useBidProvider();
@@ -34,10 +32,6 @@ const NFTCardActions: React.FC<NFTCardActionsProps> = ({
 
 	const [highestBid, setHighestBid] = useState<number | undefined>();
 	const [isLoading, setIsLoading] = useState<boolean>(true);
-
-	const buttonClick = () => {
-		onButtonClick(domain);
-	};
 
 	const getBids = async () => {
 		const bids = await getBidsForDomain(domain);
@@ -82,10 +76,13 @@ const NFTCardActions: React.FC<NFTCardActionsProps> = ({
 					</>
 				)}
 			</div>
-			{!hideButton && (
-				<BidButton glow={!disableButton} onClick={buttonClick}>
-					Make A Bid
-				</BidButton>
+			{onBtnClick && (
+				<ViewBids
+					style={{ marginLeft: 'auto', textTransform: 'uppercase' }}
+					domain={domain}
+					onClick={onBtnClick}
+					filterOwnBids={filterOwnBids}
+				/>
 			)}
 		</div>
 	);

--- a/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTable.tsx
+++ b/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTable.tsx
@@ -232,7 +232,7 @@ const OwnedDomainTables: React.FC<OwnedDomainTableProps> = ({ onNavigate }) => {
 				ignoreAspectRatios={true}
 				rowButtonText={'View Bids'}
 				onLoad={tableLoaded}
-				onRowButtonClick={viewBid}
+				onBtnClick={viewBid}
 				onRowClick={rowClick}
 				isGridView={isGridView}
 				setIsGridView={(grid: boolean) => setIsGridView(grid)}

--- a/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTable.tsx
+++ b/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTable.tsx
@@ -232,7 +232,7 @@ const OwnedDomainTables: React.FC<OwnedDomainTableProps> = ({ onNavigate }) => {
 				ignoreAspectRatios={true}
 				rowButtonText={'View Bids'}
 				onLoad={tableLoaded}
-				onBtnClick={viewBid}
+				onButtonClick={viewBid}
 				onRowClick={rowClick}
 				isGridView={isGridView}
 				setIsGridView={(grid: boolean) => setIsGridView(grid)}

--- a/src/pages/ZNS/ZNS.tsx
+++ b/src/pages/ZNS/ZNS.tsx
@@ -627,7 +627,7 @@ const ZNS: React.FC<ZNSProps> = ({ domain, version, isNftView: nftView }) => {
 				</PageHeader>
 
 				<BannerContainer isScrollDetectionDown={isScrollDetectionDown}>
-          {/* Temporarily removed Raffle */}
+					{/* Temporarily removed Raffle */}
 					<WheelsRaffle />
 					{/* <MessageBanner
 						label="This is a banner message"


### PR DESCRIPTION
Link to associated zer0 card:  [Zero Card on Notion](https://www.notion.so/Add-a-View-Bids-button-to-NFT-Grid-View-in-Owned-Domains-Table-fdf5ce5f3afb4e5ca1bcc624ef5fafd1)

-----

## 1. Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] zer0 card has been moved to the Code Review column
- [x] zer0 card has a link to this PR
- [x] A reviewer has been tagged in the zer0 card

## 2. PR type
- [x] Feature

## 3. What is the current behaviour?
NFT card on the owned domain table does not currently have a cta to view bids when in grid view.

## 4. What is the new behaviour?
View bids cta has been added to NFT card on the owned domain table when in grid view.

<img width="1469" alt="Screenshot 2021-12-30 at 13 25 08" src="https://user-images.githubusercontent.com/39112648/147755947-68d71a59-0340-4128-b7a3-bb83922563b1.png">
