### PR TITLE
Add flexible formatByDecimalPlace util function and tests

### DIFF
--- a/src/lib/utils/number.spec.ts
+++ b/src/lib/utils/number.spec.ts
@@ -1,10 +1,5 @@
 // Global Utils Imports
-import {
-	ONE_DECIMAL_PLACE_VALUE,
-	THREE_DECIMAL_PLACE_VALUE,
-	TWO_DECIMAL_PLACE_VALUE,
-	formatByDecimalPlace,
-} from '.';
+import { formatByDecimalPlace } from '.';
 
 describe('number', () => {
 	describe('formatByDecimalPlace', () => {
@@ -22,153 +17,83 @@ describe('number', () => {
 		});
 
 		it('should correctly add two decimal places to an integer when passed two places', () => {
-			expect(formatByDecimalPlace(10, TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'10.00',
-			);
-			expect(formatByDecimalPlace('10', TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'10.00',
-			);
+			expect(formatByDecimalPlace(10, 2)).toEqual('10.00');
+			expect(formatByDecimalPlace('10', 2)).toEqual('10.00');
 		});
 
 		it('should correctly add one decimal places to an integer when passed one place', () => {
-			expect(formatByDecimalPlace(10, ONE_DECIMAL_PLACE_VALUE)).toEqual('10.0');
-			expect(formatByDecimalPlace('10', ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'10.0',
-			);
+			expect(formatByDecimalPlace(10, 1)).toEqual('10.0');
+			expect(formatByDecimalPlace('10', 1)).toEqual('10.0');
 		});
 
 		it('should correctly add three decimal places to an integer when passed three places', () => {
-			expect(formatByDecimalPlace(10, THREE_DECIMAL_PLACE_VALUE)).toEqual(
-				'10.000',
-			);
-			expect(formatByDecimalPlace('10', THREE_DECIMAL_PLACE_VALUE)).toEqual(
-				'10.000',
-			);
+			expect(formatByDecimalPlace(10, 3)).toEqual('10.000');
+			expect(formatByDecimalPlace('10', 3)).toEqual('10.000');
 		});
 
 		it('should correctly add thousand separators', () => {
-			expect(formatByDecimalPlace(1000000, ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'1,000,000.0',
-			);
-			expect(formatByDecimalPlace('1000000', ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'1,000,000.0',
-			);
-			expect(formatByDecimalPlace(10000, ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'10,000.0',
-			);
-			expect(formatByDecimalPlace('10000', ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'10,000.0',
-			);
-			expect(formatByDecimalPlace(1000, ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'1,000.0',
-			);
-			expect(formatByDecimalPlace('1000', ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'1,000.0',
-			);
+			expect(formatByDecimalPlace(1000000, 1)).toEqual('1,000,000.0');
+			expect(formatByDecimalPlace('1000000', 1)).toEqual('1,000,000.0');
+			expect(formatByDecimalPlace(10000, 1)).toEqual('10,000.0');
+			expect(formatByDecimalPlace('10000', 1)).toEqual('10,000.0');
+			expect(formatByDecimalPlace(1000, 1)).toEqual('1,000.0');
+			expect(formatByDecimalPlace('1000', 1)).toEqual('1,000.0');
 		});
 
 		it('should not add thousand separators to numbers lower than 1000', () => {
-			expect(formatByDecimalPlace(9, TWO_DECIMAL_PLACE_VALUE)).toEqual('9.00');
-			expect(formatByDecimalPlace('9', TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'9.00',
-			);
-			expect(formatByDecimalPlace(99, TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'99.00',
-			);
-			expect(formatByDecimalPlace('99', TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'99.00',
-			);
-			expect(formatByDecimalPlace(999, TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'999.00',
-			);
-			expect(formatByDecimalPlace('999', TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'999.00',
-			);
+			expect(formatByDecimalPlace(9, 2)).toEqual('9.00');
+			expect(formatByDecimalPlace('9', 2)).toEqual('9.00');
+			expect(formatByDecimalPlace(99, 2)).toEqual('99.00');
+			expect(formatByDecimalPlace('99', 2)).toEqual('99.00');
+			expect(formatByDecimalPlace(999, 2)).toEqual('999.00');
+			expect(formatByDecimalPlace('999', 2)).toEqual('999.00');
 		});
 
 		it('should correctly add thousand separators and one decimal place for floating point numbers', () => {
-			expect(formatByDecimalPlace(99999.9, ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'99,999.9',
-			);
-			expect(formatByDecimalPlace('99999.9', ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'99,999.9',
-			);
-			expect(formatByDecimalPlace(99999.1, ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'99,999.1',
-			);
-			expect(formatByDecimalPlace('99999.1', ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'99,999.1',
-			);
+			expect(formatByDecimalPlace(99999.9, 1)).toEqual('99,999.9');
+			expect(formatByDecimalPlace('99999.9', 1)).toEqual('99,999.9');
+			expect(formatByDecimalPlace(99999.1, 1)).toEqual('99,999.1');
+			expect(formatByDecimalPlace('99999.1', 1)).toEqual('99,999.1');
 		});
 
 		it('should not add thousand separators to floating point numbers lower than 1000', () => {
-			expect(formatByDecimalPlace(5.5, TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'5.50',
-			);
-			expect(formatByDecimalPlace('5.5', TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'5.50',
-			);
-			expect(
-				formatByDecimalPlace(55.532222222, TWO_DECIMAL_PLACE_VALUE),
-			).toEqual('55.53');
-			expect(
-				formatByDecimalPlace('55.532222222', TWO_DECIMAL_PLACE_VALUE),
-			).toEqual('55.53');
-			expect(formatByDecimalPlace(999.681, TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'999.68',
-			);
-			expect(formatByDecimalPlace('999.681', TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'999.68',
-			);
+			expect(formatByDecimalPlace(5.5, 2)).toEqual('5.50');
+			expect(formatByDecimalPlace('5.5', 2)).toEqual('5.50');
+			expect(formatByDecimalPlace(55.532222222, 2)).toEqual('55.53');
+			expect(formatByDecimalPlace('55.532222222', 2)).toEqual('55.53');
+			expect(formatByDecimalPlace(999.681, 2)).toEqual('999.68');
+			expect(formatByDecimalPlace('999.681', 2)).toEqual('999.68');
 		});
 
 		it('should apply standard rounding to floating point numbers', () => {
-			expect(formatByDecimalPlace(9999.00001, ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'9,999.0',
-			);
-			expect(formatByDecimalPlace(9999.99, ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'10,000.0',
-			);
+			expect(formatByDecimalPlace(9999.00001, 1)).toEqual('9,999.0');
+			expect(formatByDecimalPlace(9999.99, 1)).toEqual('10,000.0');
 		});
 
 		it('should return 0.00 if zero values are supplied', () => {
-			expect(formatByDecimalPlace(0, TWO_DECIMAL_PLACE_VALUE)).toEqual('0.00');
-			expect(formatByDecimalPlace(0.0, TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'0.00',
-			);
-			expect(formatByDecimalPlace('0', TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'0.00',
-			);
-			expect(formatByDecimalPlace('0.0', TWO_DECIMAL_PLACE_VALUE)).toEqual(
-				'0.00',
-			);
+			expect(formatByDecimalPlace(0, 2)).toEqual('0.00');
+			expect(formatByDecimalPlace(0.0, 2)).toEqual('0.00');
+			expect(formatByDecimalPlace('0', 2)).toEqual('0.00');
+			expect(formatByDecimalPlace('0.0', 2)).toEqual('0.00');
 		});
 
 		it('should return 0.0 if zero values are supplied', () => {
-			expect(formatByDecimalPlace(0, ONE_DECIMAL_PLACE_VALUE)).toEqual('0.0');
-			expect(formatByDecimalPlace(0.0, ONE_DECIMAL_PLACE_VALUE)).toEqual('0.0');
-			expect(formatByDecimalPlace('0', ONE_DECIMAL_PLACE_VALUE)).toEqual('0.0');
-			expect(formatByDecimalPlace('0.0', ONE_DECIMAL_PLACE_VALUE)).toEqual(
-				'0.0',
-			);
+			expect(formatByDecimalPlace(0, 1)).toEqual('0.0');
+			expect(formatByDecimalPlace(0.0, 1)).toEqual('0.0');
+			expect(formatByDecimalPlace('0', 1)).toEqual('0.0');
+			expect(formatByDecimalPlace('0.0', 1)).toEqual('0.0');
 		});
 
 		it('should support different user locales - English', () => {
-			expect(
-				formatByDecimalPlace(12345.67, TWO_DECIMAL_PLACE_VALUE, 'en'),
-			).toEqual('12,345.67');
+			expect(formatByDecimalPlace(12345.67, 2, 'en')).toEqual('12,345.67');
 		});
 
 		it('should support different user locales - French', () => {
-			expect(
-				formatByDecimalPlace(12345.67, TWO_DECIMAL_PLACE_VALUE, 'fr'),
-			).toEqual('12 345,67');
+			expect(formatByDecimalPlace(12345.67, 2, 'fr')).toEqual('12 345,67');
 		});
 
 		it('should support different user locales - Italian', () => {
-			expect(
-				formatByDecimalPlace(12345.67, TWO_DECIMAL_PLACE_VALUE, 'it'),
-			).toEqual('12.345,67');
+			expect(formatByDecimalPlace(12345.67, 2, 'it')).toEqual('12.345,67');
 		});
 
 		it('should fallback to the browser locale if no locale code is specified', () => {
@@ -181,7 +106,7 @@ describe('number', () => {
 				writable: true,
 			});
 
-			const actual = formatByDecimalPlace(12345.67, TWO_DECIMAL_PLACE_VALUE);
+			const actual = formatByDecimalPlace(12345.67, 2);
 			expect(actual).toEqual('12,345.67');
 		});
 	});

--- a/src/lib/utils/number.spec.ts
+++ b/src/lib/utils/number.spec.ts
@@ -1,0 +1,188 @@
+// Global Utils Imports
+import {
+	ONE_DECIMAL_PLACE_VALUE,
+	THREE_DECIMAL_PLACE_VALUE,
+	TWO_DECIMAL_PLACE_VALUE,
+	formatByDecimalPlace,
+} from '.';
+
+describe('number', () => {
+	describe('formatByDecimalPlace', () => {
+		const { language } = navigator;
+
+		afterEach(() => {
+			Object.defineProperty(navigator, 'language', {
+				value: language,
+				writable: true,
+			});
+			Object.defineProperty(navigator, 'userLanguage', {
+				value: language,
+				writable: true,
+			});
+		});
+
+		it('should correctly add two decimal places to an integer when passed two places', () => {
+			expect(formatByDecimalPlace(10, TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'10.00',
+			);
+			expect(formatByDecimalPlace('10', TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'10.00',
+			);
+		});
+
+		it('should correctly add one decimal places to an integer when passed one place', () => {
+			expect(formatByDecimalPlace(10, ONE_DECIMAL_PLACE_VALUE)).toEqual('10.0');
+			expect(formatByDecimalPlace('10', ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'10.0',
+			);
+		});
+
+		it('should correctly add three decimal places to an integer when passed three places', () => {
+			expect(formatByDecimalPlace(10, THREE_DECIMAL_PLACE_VALUE)).toEqual(
+				'10.000',
+			);
+			expect(formatByDecimalPlace('10', THREE_DECIMAL_PLACE_VALUE)).toEqual(
+				'10.000',
+			);
+		});
+
+		it('should correctly add thousand separators', () => {
+			expect(formatByDecimalPlace(1000000, ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'1,000,000.0',
+			);
+			expect(formatByDecimalPlace('1000000', ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'1,000,000.0',
+			);
+			expect(formatByDecimalPlace(10000, ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'10,000.0',
+			);
+			expect(formatByDecimalPlace('10000', ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'10,000.0',
+			);
+			expect(formatByDecimalPlace(1000, ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'1,000.0',
+			);
+			expect(formatByDecimalPlace('1000', ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'1,000.0',
+			);
+		});
+
+		it('should not add thousand separators to numbers lower than 1000', () => {
+			expect(formatByDecimalPlace(9, TWO_DECIMAL_PLACE_VALUE)).toEqual('9.00');
+			expect(formatByDecimalPlace('9', TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'9.00',
+			);
+			expect(formatByDecimalPlace(99, TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'99.00',
+			);
+			expect(formatByDecimalPlace('99', TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'99.00',
+			);
+			expect(formatByDecimalPlace(999, TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'999.00',
+			);
+			expect(formatByDecimalPlace('999', TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'999.00',
+			);
+		});
+
+		it('should correctly add thousand separators and one decimal place for floating point numbers', () => {
+			expect(formatByDecimalPlace(99999.9, ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'99,999.9',
+			);
+			expect(formatByDecimalPlace('99999.9', ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'99,999.9',
+			);
+			expect(formatByDecimalPlace(99999.1, ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'99,999.1',
+			);
+			expect(formatByDecimalPlace('99999.1', ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'99,999.1',
+			);
+		});
+
+		it('should not add thousand separators to floating point numbers lower than 1000', () => {
+			expect(formatByDecimalPlace(5.5, TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'5.50',
+			);
+			expect(formatByDecimalPlace('5.5', TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'5.50',
+			);
+			expect(
+				formatByDecimalPlace(55.532222222, TWO_DECIMAL_PLACE_VALUE),
+			).toEqual('55.53');
+			expect(
+				formatByDecimalPlace('55.532222222', TWO_DECIMAL_PLACE_VALUE),
+			).toEqual('55.53');
+			expect(formatByDecimalPlace(999.681, TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'999.68',
+			);
+			expect(formatByDecimalPlace('999.681', TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'999.68',
+			);
+		});
+
+		it('should apply standard rounding to floating point numbers', () => {
+			expect(formatByDecimalPlace(9999.00001, ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'9,999.0',
+			);
+			expect(formatByDecimalPlace(9999.99, ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'10,000.0',
+			);
+		});
+
+		it('should return 0.00 if zero values are supplied', () => {
+			expect(formatByDecimalPlace(0, TWO_DECIMAL_PLACE_VALUE)).toEqual('0.00');
+			expect(formatByDecimalPlace(0.0, TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'0.00',
+			);
+			expect(formatByDecimalPlace('0', TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'0.00',
+			);
+			expect(formatByDecimalPlace('0.0', TWO_DECIMAL_PLACE_VALUE)).toEqual(
+				'0.00',
+			);
+		});
+
+		it('should return 0.0 if zero values are supplied', () => {
+			expect(formatByDecimalPlace(0, ONE_DECIMAL_PLACE_VALUE)).toEqual('0.0');
+			expect(formatByDecimalPlace(0.0, ONE_DECIMAL_PLACE_VALUE)).toEqual('0.0');
+			expect(formatByDecimalPlace('0', ONE_DECIMAL_PLACE_VALUE)).toEqual('0.0');
+			expect(formatByDecimalPlace('0.0', ONE_DECIMAL_PLACE_VALUE)).toEqual(
+				'0.0',
+			);
+		});
+
+		it('should support different user locales - English', () => {
+			expect(
+				formatByDecimalPlace(12345.67, TWO_DECIMAL_PLACE_VALUE, 'en'),
+			).toEqual('12,345.67');
+		});
+
+		it('should support different user locales - French', () => {
+			expect(
+				formatByDecimalPlace(12345.67, TWO_DECIMAL_PLACE_VALUE, 'fr'),
+			).toEqual('12 345,67');
+		});
+
+		it('should support different user locales - Italian', () => {
+			expect(
+				formatByDecimalPlace(12345.67, TWO_DECIMAL_PLACE_VALUE, 'it'),
+			).toEqual('12.345,67');
+		});
+
+		it('should fallback to the browser locale if no locale code is specified', () => {
+			Object.defineProperty(navigator, 'language', {
+				value: 'de',
+				writable: true,
+			});
+			Object.defineProperty(navigator, 'userLanguage', {
+				value: 'de',
+				writable: true,
+			});
+
+			const actual = formatByDecimalPlace(12345.67, TWO_DECIMAL_PLACE_VALUE);
+			expect(actual).toEqual('12,345.67');
+		});
+	});
+});

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -13,10 +13,6 @@ export const formatEthers = (number: string) => {
 	return formatNumber(asNumber);
 };
 
-export const ONE_DECIMAL_PLACE_VALUE = 1;
-export const TWO_DECIMAL_PLACE_VALUE = 2;
-export const THREE_DECIMAL_PLACE_VALUE = 3;
-
 export const formatByDecimalPlace = (
 	value: number | string,
 	places: number,

--- a/src/lib/utils/number.ts
+++ b/src/lib/utils/number.ts
@@ -12,3 +12,17 @@ export const formatEthers = (number: string) => {
 	const asNumber = Number(ethers.utils.formatEther(number));
 	return formatNumber(asNumber);
 };
+
+export const ONE_DECIMAL_PLACE_VALUE = 1;
+export const TWO_DECIMAL_PLACE_VALUE = 2;
+export const THREE_DECIMAL_PLACE_VALUE = 3;
+
+export const formatByDecimalPlace = (
+	value: number | string,
+	places: number,
+	localeCode?: string,
+	config = { maximumFractionDigits: places, minimumFractionDigits: places },
+) => {
+	const number = Number(value);
+	return Number.isNaN(number) ? '' : number.toLocaleString(localeCode, config);
+};


### PR DESCRIPTION
Link to associated zer0 card:  [Notion Card](https://www.notion.so/rational-nomads/67a5d1b61d4146f491d5996a17b14a81?v=4f04ed31a23340bfbbdc5560502bc429&p=4d62ccf715fc40e4a0ca203edea1ced1)

-----

## 1. Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] zer0 card has been moved to the Code Review column
- [x] zer0 card has a link to this PR
- [x] A reviewer has been tagged in the zer0 card

## 2. PR type
- [x] Feature

## 3. What is the current behaviour?
Existing format number util doesn't allow us to pass a desired amount of decimal places to display in the UI on a value.

## 4. What is the new behaviour?
New formatByDecimalPlace util allows us to add a desired amount of decimal places to display. Fully tested.

## 5. Other information
The reason for this ticket was due to displaying wild percentage change in ui. This PR will need to be merged first.
[Loom](https://www.loom.com/share/65afb1e2c2a1429096a6ff65d5535cd5)