### PR TITLE
Fix total staked loader for users with no deposits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "staking-dapp",
-	"version": "0.1.2",
+	"version": "0.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "staking-dapp",
-			"version": "0.1.2",
+			"version": "0.2.0",
 			"dependencies": {
 				"@apollo/client": "^3.3.13",
 				"@ethersproject/abi": "^5.1.0",

--- a/src/containers/staking/Deposits/Deposits.tsx
+++ b/src/containers/staking/Deposits/Deposits.tsx
@@ -124,7 +124,7 @@ const Deposits = () => {
 					<StatsWidget
 						className="normalView"
 						fieldName={'Your Total Stake (USD)'}
-						isLoading={account !== null && !totalStakedUsd}
+						isLoading={account !== null && totalStakedUsd === undefined}
 						title={
 							account && totalStakedUsd !== undefined
 								? '$' + toFiat(totalStakedUsd) + ' USD'


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/Handle-infinite-loading-staked-balance-issue-2f86268078ee4cdda574f475b85272a4)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Bugfix

## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

"Total Stake (USD)" widget would load infinitely if the user hasn't made any deposits.

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

Widget now shows "$0", as it should, if the user hasn't made any deposits.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->

-