### PR TITLE
Release 0.11.3 - MIME type hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "zns-dapp",
-	"version": "0.11.0",
+	"version": "0.11.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "zns-dapp",
-			"version": "0.11.0",
+			"version": "0.11.2",
 			"dependencies": {
 				"@apollo/client": "^3.3.13",
 				"@ethersproject/abi": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zns-dapp",
-	"version": "0.11.2",
+	"version": "0.11.3",
 	"private": true,
 	"dependencies": {
 		"@apollo/client": "^3.3.13",

--- a/src/components/NFTMedia/index.tsx
+++ b/src/components/NFTMedia/index.tsx
@@ -23,6 +23,7 @@ import CloudinaryMedia from './CloudinaryMedia';
 // Library Imports
 import classNames from 'classnames/bind';
 import { getHashFromIPFSUrl } from 'lib/ipfs';
+import { generateCloudinaryUrl } from './config';
 
 // Possible media types based on
 // MIME type of content
@@ -38,22 +39,16 @@ const cx = classNames.bind(styles);
 // Useful because our IPFS links don't have
 // a file extension
 export const checkMediaType = (hash: string) => {
-	return new Promise((resolve, reject) => {
-		fetch('https://gateway.ipfs.io/ipfs/' + hash, { method: 'HEAD' })
-			.then((r: Response) => {
-				const contentTypeHeader = r.headers.get('Content-Type');
-
-				if (contentTypeHeader?.startsWith('image')) {
-					resolve(MediaType.Image);
-				} else if (contentTypeHeader?.startsWith('video')) {
+	return new Promise((resolve) => {
+		fetch(generateCloudinaryUrl(hash, 'video'), { method: 'HEAD' }).then(
+			(d: Response) => {
+				if (d.status === 200) {
 					resolve(MediaType.Video);
 				} else {
-					resolve(MediaType.Unknown);
+					resolve(MediaType.Image);
 				}
-			})
-			.catch(() => {
-				resolve(MediaType.Unknown);
-			});
+			},
+		);
 	});
 };
 


### PR DESCRIPTION
NFTMedia was previously relying on IPFS to grab MIME type. IPFS is less reliable than Cloudinary, so we should use Cloudinary as our source of MIME type.

Further adjustments to logic will be needed, but this works as a bandaid.