### PR TITLE
Hide loading spinners on smaller breakpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zns-dapp",
-	"version": "0.11.3",
+	"version": "0.11.4",
 	"private": true,
 	"dependencies": {
 		"@apollo/client": "^3.3.13",

--- a/src/containers/Tables/SubdomainTable/SubdomainTableRow.tsx
+++ b/src/containers/Tables/SubdomainTable/SubdomainTableRow.tsx
@@ -145,10 +145,10 @@ const SubdomainTableRow = (props: any) => {
 					<td className={styles.Right}>
 						<Spinner />
 					</td>
-					<td className={styles.Right}>
+					<td className={`${styles.Right} ${styles.lastSaleCol}`}>
 						<Spinner />
 					</td>
-					<td className={styles.Right}>
+					<td className={`${styles.Right} ${styles.volumeCol}`}>
 						<Spinner />
 					</td>
 				</>


### PR DESCRIPTION
**Old behaviour:**

On smaller breakpoints, loading spinners weren't being hidden.

<img width="635" alt="Screen Shot 2022-02-07 at 10 20 41 PM" src="https://user-images.githubusercontent.com/12437916/152760313-9c9b0766-945f-47f1-b60d-919482e23e1b.png">

**New behaviour:**

Spinners for hidden columns are actually hidden.