### PR TITLE
[Bug] Disconnecting wallet broken UI fix

### DIFF
--- a/src/components/ConnectToWallet/ConnectToWallet.tsx
+++ b/src/components/ConnectToWallet/ConnectToWallet.tsx
@@ -19,6 +19,9 @@ import WalletStyles from './Wallet.module.scss';
 //- Component Imports
 import { FutureButton, Spinner, Image } from 'components';
 
+//- Utils Imports
+import { WalletOptionType, getWalletOptionStyle } from './utils';
+
 //- Asset Imports
 import metamaskIcon from './assets/metamask.svg';
 import walletConnectIcon from './assets/walletconnect.svg';
@@ -39,7 +42,7 @@ const nameToConnector: { [key: string]: AbstractConnector } = {
 };
 
 export const connectorFromName = (name: string) => {
-	if (name === 'walletconnect') {
+	if (name === WalletOptionType.WALLET_CONNECT) {
 		return createWalletConnectConnector();
 	}
 
@@ -76,7 +79,7 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 
 		if (c) {
 			//if user tries to connect metamask without provider
-			if (wallet === 'metamask' && !window.ethereum) {
+			if (wallet === WalletOptionType.METAMASK && !window.ethereum) {
 				addNotification(
 					'Unable to find Metamask. Please check it is installed.',
 				);
@@ -89,12 +92,12 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 			localStorage.setItem('chosenWallet', wallet); //sets the actual wallet key to reconnect if connected
 
 			//metamask may get stuck due to eth_requestAccounts promise, if user close log in overlay
-			if (wallet === 'metamask') {
+			if (wallet === WalletOptionType.METAMASK) {
 				setTimeout(async () => {
 					const authorized = await injected.isAuthorized();
 					if (
 						!authorized &&
-						localStorage.getItem('chosenWallet') === 'metamask'
+						localStorage.getItem('chosenWallet') === WalletOptionType.METAMASK
 					)
 						addNotification('Cant connect?, please reload and retry');
 				}, 20000); //@todo: check if metamask solves this, issue #10085
@@ -121,20 +124,20 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 		deactivate();
 		//if has a wallet connected, instead of just deactivate, close connection too
 		switch (wallet) {
-			case 'coinbase': {
+			case WalletOptionType.COINBASE: {
 				walletlink.close();
 				break;
 			}
-			case 'portis': {
+			case WalletOptionType.PORTIS: {
 				portis.close();
 				break;
 			}
-			case 'fortmatic': {
+			case WalletOptionType.FORTMATIC: {
 				fortmatic.close();
 				break;
 			}
-			case 'walletconnect': {
-				localStorage.removeItem('walletconnect'); //session info of walletconnect
+			case WalletOptionType.WALLET_CONNECT: {
+				localStorage.removeItem(WalletOptionType.WALLET_CONNECT); //session info of walletconnect
 				break;
 			}
 			default:
@@ -197,8 +200,8 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 			{!isLoading && (
 				<ul>
 					<li
-						onClick={() => connectToWallet('metamask')}
-						className={WalletStyles.wallet}
+						onClick={() => connectToWallet(WalletOptionType.METAMASK)}
+						className={getWalletOptionStyle(WalletOptionType.METAMASK)}
 					>
 						Metamask
 						<div>
@@ -210,8 +213,8 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 						</div>
 					</li>
 					<li
-						onClick={() => connectToWallet('walletconnect')}
-						className={WalletStyles.wallet}
+						onClick={() => connectToWallet(WalletOptionType.WALLET_CONNECT)}
+						className={getWalletOptionStyle(WalletOptionType.WALLET_CONNECT)}
 					>
 						<span>Wallet Connect</span>
 						<div>
@@ -219,8 +222,8 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 						</div>
 					</li>
 					<li
-						onClick={() => connectToWallet('coinbase')}
-						className={WalletStyles.wallet}
+						onClick={() => connectToWallet(WalletOptionType.COINBASE)}
+						className={getWalletOptionStyle(WalletOptionType.COINBASE)}
 					>
 						<span>Coinbase Wallet</span>
 						<div>
@@ -228,8 +231,8 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 						</div>
 					</li>
 					<li
-						onClick={() => connectToWallet('fortmatic')}
-						className={WalletStyles.wallet}
+						onClick={() => connectToWallet(WalletOptionType.FORTMATIC)}
+						className={getWalletOptionStyle(WalletOptionType.FORTMATIC)}
 					>
 						<span>Fortmatic</span>
 						<div>
@@ -237,8 +240,8 @@ const ConnectToWallet: React.FC<ConnectToWalletProps> = ({ onConnect }) => {
 						</div>
 					</li>
 					<li
-						onClick={() => connectToWallet('portis')}
-						className={WalletStyles.wallet}
+						onClick={() => connectToWallet(WalletOptionType.PORTIS)}
+						className={getWalletOptionStyle(WalletOptionType.PORTIS)}
 					>
 						<span>Portis</span>
 						<div>

--- a/src/components/ConnectToWallet/Wallet.module.scss
+++ b/src/components/ConnectToWallet/Wallet.module.scss
@@ -124,3 +124,8 @@
 	color: var(--color-accent-1);
 	text-decoration: none;
 }
+
+.Disabled {
+	pointer-events: none;
+	opacity: 0.6;
+}

--- a/src/components/ConnectToWallet/utils.ts
+++ b/src/components/ConnectToWallet/utils.ts
@@ -1,0 +1,17 @@
+//- Style Imports
+import WalletStyles from './Wallet.module.scss';
+
+export enum WalletOptionType {
+	METAMASK = 'metamask',
+	COINBASE = 'coinbase',
+	WALLET_CONNECT = 'walletconnect',
+	FORTMATIC = 'fortmatic',
+	PORTIS = 'portis',
+}
+
+export const getWalletOptionStyle = (walletType: string) =>
+	`${WalletStyles.wallet} ${
+		localStorage.getItem('chosenWallet') === walletType
+			? WalletStyles.Disabled
+			: WalletStyles.wallet
+	}`;

--- a/src/containers/PageContainer/index.tsx
+++ b/src/containers/PageContainer/index.tsx
@@ -6,6 +6,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { useWeb3React } from '@web3-react/core';
 import { Web3Provider } from '@ethersproject/providers/lib/web3-provider';
 import { useEagerConnect } from 'lib/hooks/provider-hooks';
+import { injected } from 'lib/connectors';
 
 //- Library Imports
 import { useChainSelector } from 'lib/providers/ChainSelectorProvider';
@@ -61,7 +62,6 @@ const PageContainer: FC = ({ children }) => {
 
 	const { account, active, chainId } = walletContext;
 	const triedEagerConnect = useEagerConnect(); // This line will try auto-connect to the last wallet only if the user hasn't disconnected
-
 	//- Chain Selection (@todo: refactor to provider)
 	const chainSelector = useChainSelector();
 
@@ -157,6 +157,7 @@ const PageContainer: FC = ({ children }) => {
 	const closeModal = () => {
 		setModal(undefined);
 	};
+
 	const openMint = () => setModal(Modal.Mint);
 
 	const openProfile = () => {
@@ -211,11 +212,14 @@ const PageContainer: FC = ({ children }) => {
 	useEffect(() => {
 		//wallet connect wont do this automatically if session its ended from phone
 		if (
-			localStorage.getItem('chosenWallet') === 'walletconnect' &&
+			(localStorage.getItem('chosenWallet') === 'walletconnect' ||
+				localStorage.getItem('chosenWallet') === 'metamask' ||
+				localStorage.getItem('chosenWallet') === 'coinbase' ||
+				localStorage.getItem('chosenWallet') === 'portis' ||
+				localStorage.getItem('chosenWallet') === 'fortmatic') &&
 			!active &&
 			triedEagerConnect
 		) {
-			localStorage.removeItem('walletconnect');
 			localStorage.removeItem('chosenWallet');
 		}
 		if (triedEagerConnect)
@@ -311,7 +315,6 @@ const PageContainer: FC = ({ children }) => {
 										justifyContent: 'center',
 										verticalAlign: 'center',
 										alignItems: 'center',
-										paddingBottom: '5px',
 									}}
 								>
 									<div
@@ -327,10 +330,11 @@ const PageContainer: FC = ({ children }) => {
 									<p
 										style={{
 											display: 'inline-block',
-											width: '90%',
+											width: '100%',
 											verticalAlign: 'center',
 											height: '18px',
 											marginLeft: '15px',
+											whiteSpace: 'nowrap',
 										}}
 										className={styles.Message}
 									>

--- a/src/containers/PageContainer/index.tsx
+++ b/src/containers/PageContainer/index.tsx
@@ -220,7 +220,9 @@ const PageContainer: FC = ({ children }) => {
 			!active &&
 			triedEagerConnect
 		) {
-			localStorage.removeItem('chosenWallet');
+			setTimeout(async () => {
+				localStorage.removeItem('chosenWallet');
+			}, 2000);
 		}
 		if (triedEagerConnect)
 			addNotification(active ? 'Wallet connected.' : 'Wallet disconnected.');

--- a/src/containers/PageContainer/index.tsx
+++ b/src/containers/PageContainer/index.tsx
@@ -6,7 +6,6 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { useWeb3React } from '@web3-react/core';
 import { Web3Provider } from '@ethersproject/providers/lib/web3-provider';
 import { useEagerConnect } from 'lib/hooks/provider-hooks';
-import { injected } from 'lib/connectors';
 
 //- Library Imports
 import { useChainSelector } from 'lib/providers/ChainSelectorProvider';


### PR DESCRIPTION
[Associated Notion Card](https://www.notion.so/rational-nomads/67a5d1b61d4146f491d5996a17b14a81?v=4f04ed31a23340bfbbdc5560502bc429&p=ef867c85e24a4a48a58208dc23fcc0c5)

-----

## 1. Pull request checklist
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] Bug Fix

## 3. What is the old behaviour?
1. When disconnecting from metamask wallet the "Trying to reconnect metamask" and spinner has a line break. In addition, the wallet has already disconnected, therefore the message displayed is void. 

2. When connected to a wallet, the user can still select this option from the ConnectWallet component. 

## 4. What is the new behaviour?
1. Fixed line break in "Trying to connect to metamask". Added additional logic to determine if the wallet is reconnecting. Display 'Connect' button is wallet is disconnect and connection has been re-tried.

2. Disable current connected wallet from wallet options.
