### PR TITLE
Circle CI build failing fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:16.13.2
+      - image: circleci/node
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node
+      - image: circleci/node:16.13.2
     steps:
       - checkout
       - restore_cache:

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
 				"@types/autosize": "^4.0.0",
 				"@types/clipboard": "^2.0.1",
 				"@types/graphql": "^14.5.0",
-				"@types/jest": "^26.0.22",
+				"@types/jest": "^26.0.24",
 				"@types/jquery": "^3.5.5",
 				"@types/lodash": "^4.14.168",
 				"@types/node": "^14.14.37",
@@ -6493,8 +6493,9 @@
 			}
 		},
 		"node_modules/@types/jest": {
-			"version": "26.0.23",
-			"license": "MIT",
+			"version": "26.0.24",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+			"integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
 			"dependencies": {
 				"jest-diff": "^26.0.0",
 				"pretty-format": "^26.0.0"
@@ -40165,7 +40166,9 @@
 			}
 		},
 		"@types/jest": {
-			"version": "26.0.23",
+			"version": "26.0.24",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+			"integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
 			"requires": {
 				"jest-diff": "^26.0.0",
 				"pretty-format": "^26.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@fleekhq/fleek-storage-js": "^1.0.14",
 				"@hookform/resolvers": "^1.3.7",
 				"@react-hook/window-scroll": "^1.3.0",
-				"@testing-library/jest-dom": "^5.11.10",
+				"@testing-library/jest-dom": "^5.16.2",
 				"@testing-library/react": "^11.2.6",
 				"@testing-library/user-event": "^12.8.3",
 				"@types/react-lazyload": "^3.1.1",
@@ -6113,12 +6113,13 @@
 			}
 		},
 		"node_modules/@testing-library/jest-dom": {
-			"version": "5.14.1",
-			"license": "MIT",
+			"version": "5.16.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
+			"integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
 			"dependencies": {
 				"@babel/runtime": "^7.9.2",
 				"@types/testing-library__jest-dom": "^5.9.1",
-				"aria-query": "^4.2.2",
+				"aria-query": "^5.0.0",
 				"chalk": "^3.0.0",
 				"css": "^3.0.0",
 				"css.escape": "^1.5.1",
@@ -6143,6 +6144,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/aria-query": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+			"integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+			"engines": {
+				"node": ">=6.0"
 			}
 		},
 		"node_modules/@testing-library/jest-dom/node_modules/chalk": {
@@ -16406,7 +16415,9 @@
 		"node_modules/ganache-core": {
 			"version": "2.13.2",
 			"bundleDependencies": [
-				"keccak"
+				"keccak",
+				"node-addon-api",
+				"node-gyp-build"
 			],
 			"license": "MIT",
 			"dependencies": {
@@ -39874,11 +39885,13 @@
 			}
 		},
 		"@testing-library/jest-dom": {
-			"version": "5.14.1",
+			"version": "5.16.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
+			"integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
 				"@types/testing-library__jest-dom": "^5.9.1",
-				"aria-query": "^4.2.2",
+				"aria-query": "^5.0.0",
 				"chalk": "^3.0.0",
 				"css": "^3.0.0",
 				"css.escape": "^1.5.1",
@@ -39892,6 +39905,11 @@
 					"requires": {
 						"color-convert": "^2.0.1"
 					}
+				},
+				"aria-query": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+					"integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg=="
 				},
 				"chalk": {
 					"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"@fleekhq/fleek-storage-js": "^1.0.14",
 		"@hookform/resolvers": "^1.3.7",
 		"@react-hook/window-scroll": "^1.3.0",
-		"@testing-library/jest-dom": "^5.11.10",
+		"@testing-library/jest-dom": "^5.16.2",
 		"@testing-library/react": "^11.2.6",
 		"@testing-library/user-event": "^12.8.3",
 		"@types/react-lazyload": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 	"scripts": {
 		"start": "react-scripts start",
 		"build": "npm run generate-meta-tag && react-scripts build",
-		"test": "react-scripts test",
+		"test": "react-scripts test jest --detectOpenHandles --maxWorkers=2",
 		"testci": "react-scripts test --coverage",
 		"eject": "react-scripts eject",
 		"typegen": "typechain --target ethers-v5 --outDir src/types \"src/abi/**/*.json\"",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 	"scripts": {
 		"start": "react-scripts start",
 		"build": "npm run generate-meta-tag && react-scripts build",
-		"test": "react-scripts test jest --detectOpenHandles --maxWorkers=2",
+		"test": "react-scripts test --detectOpenHandles --maxWorkers=2",
 		"testci": "react-scripts test --coverage",
 		"eject": "react-scripts eject",
 		"typegen": "typechain --target ethers-v5 --outDir src/types \"src/abi/**/*.json\"",

--- a/src/components/Cards/PreviewCard/Previewcard.test.tsx
+++ b/src/components/Cards/PreviewCard/Previewcard.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { render, cleanup } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import PreviewCard, { TEST_IDS } from './PreviewCard';
+import '@testing-library/jest-dom/extend-expect';
 
 const renderComponent = ({
 	preventInteraction = false,
@@ -30,7 +29,9 @@ const renderComponent = ({
 			name={name}
 			ownerId={ownerId}
 			style={style}
-		/>,
+		>
+			{children}
+		</PreviewCard>,
 	);
 };
 


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/dApp-Core-Product-Team-Board-e96437225e264ae8ae8d46ca5f4d7b35?p=585150edf7844452bfffc96f40737e87)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
BugFix


## 3. What is the old behaviour?
Circle Ci build fails on Preview Card Test
<img width="1198" alt="Screenshot 2022-02-28 at 12 39 26" src="https://user-images.githubusercontent.com/39112648/155984949-505ff893-bfe9-4ed4-b6fe-404d5fa6d624.png">

<img width="1228" alt="Screenshot 2022-02-28 at 12 39 44" src="https://user-images.githubusercontent.com/39112648/155984987-2d354670-033c-4ba1-8388-f66067fc111f.png">

```A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks```

## 4. What is the new behaviour?
Circle Ci build passes

Added detectOpenHandles
Attempt to collect and print open handles preventing Jest from exiting cleanly. Use this in cases where you need to use --forceExit in order for Jest to exit to potentially track down the reason. This implies --runInBand, making tests run serially. Implemented using [async_hooks](https://nodejs.org/api/async_hooks.html).

Added maxWorkers
Alias: -w. Specifies the maximum number of workers the worker-pool will spawn for running tests. In single run mode, this defaults to the number of the cores available on your machine minus one for the main thread. In watch mode, this defaults to half of the available cores on your machine to ensure Jest is unobtrusive and does not grind your machine to a halt. It may be useful to adjust this in resource limited environments like CIs but the defaults should be adequate for most use-cases.

<img width="1228" alt="Screenshot 2022-02-28 at 13 13 16" src="https://user-images.githubusercontent.com/39112648/155989282-fd8d6a55-fda9-4427-99b4-5277901600c5.png">

