### PR TITLE
Firefox browser backgrounds fix

### DIFF
--- a/src/components/Banners/NextDrop/NextDrop.js
+++ b/src/components/Banners/NextDrop/NextDrop.js
@@ -30,7 +30,7 @@ const NextDrop = (props) => {
 	return (
 		<div
 			style={{ ...props.style }}
-			className={`${styles.nextDrop} border-primary border-rounded background-primary blur`}
+			className={`${styles.nextDrop} border-primary border-rounded background-primary`}
 		>
 			<img alt="Artist Profile" src={avatar} />
 			<div>

--- a/src/components/Banners/NextDrop/NextDrop.js
+++ b/src/components/Banners/NextDrop/NextDrop.js
@@ -30,7 +30,7 @@ const NextDrop = (props) => {
 	return (
 		<div
 			style={{ ...props.style }}
-			className={`${styles.nextDrop} border-primary border-rounded blur`}
+			className={`${styles.nextDrop} border-primary border-rounded background-primary blur`}
 		>
 			<img alt="Artist Profile" src={avatar} />
 			<div>

--- a/src/components/Confirmation/Confirmation.tsx
+++ b/src/components/Confirmation/Confirmation.tsx
@@ -57,7 +57,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
 
 	return (
 		<div
-			className={`${styles.Confirmation} blur border-primary border-rounded background-primary `}
+			className={`${styles.Confirmation} border-primary border-rounded background-primary `}
 		>
 			<h2 className="glow-text-white">{title ?? 'Are you sure?'}</h2>
 			{hasCloseButton && (

--- a/src/components/Confirmation/Confirmation.tsx
+++ b/src/components/Confirmation/Confirmation.tsx
@@ -57,7 +57,7 @@ const Confirmation: React.FC<ConfirmationProps> = ({
 
 	return (
 		<div
-			className={`${styles.Confirmation} blur border-primary border-rounded`}
+			className={`${styles.Confirmation} blur border-primary border-rounded background-primary `}
 		>
 			<h2 className="glow-text-white">{title ?? 'Are you sure?'}</h2>
 			{hasCloseButton && (

--- a/src/components/MintPreview/MintPreview.tsx
+++ b/src/components/MintPreview/MintPreview.tsx
@@ -158,7 +158,7 @@ const MintPreview = (props: MintPreviewProps) => {
 
 	return (
 		<ul
-			className={`${styles.MintPreview} border-primary border-rounded background-primary blur`}
+			className={`${styles.MintPreview} border-primary border-rounded background-primary`}
 		>
 			{mintingSection}
 			{requestSection}

--- a/src/components/MintPreview/MintPreview.tsx
+++ b/src/components/MintPreview/MintPreview.tsx
@@ -157,7 +157,9 @@ const MintPreview = (props: MintPreviewProps) => {
 	}
 
 	return (
-		<ul className={`${styles.MintPreview} border-primary border-rounded blur`}>
+		<ul
+			className={`${styles.MintPreview} border-primary border-rounded background-primary blur`}
+		>
 			{mintingSection}
 			{requestSection}
 		</ul>

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -10,7 +10,7 @@ const Notification: React.FC<NotificationProps> = ({ text, onClick }) => {
 	return (
 		<div
 			onClick={onClick}
-			className={`${styles.Notification} background-primary blur ${
+			className={`${styles.Notification} background-primary ${
 				onClick ? styles.Clickable : ''
 			}`}
 		>

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -10,7 +10,7 @@ const Notification: React.FC<NotificationProps> = ({ text, onClick }) => {
 	return (
 		<div
 			onClick={onClick}
-			className={`${styles.Notification} blur ${
+			className={`${styles.Notification} background-primary blur ${
 				onClick ? styles.Clickable : ''
 			}`}
 		>

--- a/src/components/NotificationDrawer/NotificationDrawer.tsx
+++ b/src/components/NotificationDrawer/NotificationDrawer.tsx
@@ -24,7 +24,9 @@ const NotificationDrawer = () => {
 
 	return (
 		<div
-			className={`${styles.NotificationDrawer} blur  border-primary ${
+			className={`${
+				styles.NotificationDrawer
+			} blur border-primary background-primary ${
 				!notifications.length ? styles.Hidden : ''
 			}`}
 			data-testid={TEST_ID.CONTAINER}

--- a/src/components/NotificationDrawer/NotificationDrawer.tsx
+++ b/src/components/NotificationDrawer/NotificationDrawer.tsx
@@ -26,7 +26,7 @@ const NotificationDrawer = () => {
 		<div
 			className={`${
 				styles.NotificationDrawer
-			} blur border-primary background-primary ${
+			} border-primary background-primary ${
 				!notifications.length ? styles.Hidden : ''
 			}`}
 			data-testid={TEST_ID.CONTAINER}

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -5,7 +5,10 @@ import searchBarStyles from './SearchBar.module.scss';
 // TODO: Convert to TypeScript
 const SearchBar = (props) => {
 	return (
-		<div className={searchBarStyles.searchBar + ' blur'} style={props.style}>
+		<div
+			className={searchBarStyles.searchBar + '  background-primary blur'}
+			style={props.style}
+		>
 			<input
 				onChange={props.onChange}
 				type="text"

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -6,7 +6,7 @@ import searchBarStyles from './SearchBar.module.scss';
 const SearchBar = (props) => {
 	return (
 		<div
-			className={searchBarStyles.searchBar + '  background-primary blur'}
+			className={searchBarStyles.searchBar + '  background-primary'}
 			style={props.style}
 		>
 			<input

--- a/src/components/TransferPreview/TransferPreview.tsx
+++ b/src/components/TransferPreview/TransferPreview.tsx
@@ -63,7 +63,7 @@ const TransferPreview = () => {
 
 	return (
 		<div
-			className={`${styles.TransferPreview} border-primary border-rounded background-primary blur`}
+			className={`${styles.TransferPreview} border-primary border-rounded background-primary`}
 		>
 			<h4 className="glow-text-white">{MESSAGES.TRANSFER_TITLE}</h4>
 			<ul>{transferring.map((n: any) => nft(n, false))}</ul>

--- a/src/containers/PageContainer/elements/Header/elements/SearchDomains/SearchDomains.tsx
+++ b/src/containers/PageContainer/elements/Header/elements/SearchDomains/SearchDomains.tsx
@@ -48,7 +48,7 @@ export const SearchDomains: React.FC<SearchDomainsProps> = ({
 		<Spring to={{ height: localState.containerHeight || 0 }}>
 			{(animatedStyles) => (
 				<animated.div
-					className="search-domains__results blur"
+					className="search-domains__results background-primary blur"
 					style={animatedStyles}
 				>
 					<ul ref={listRef}>

--- a/src/containers/PageContainer/elements/Header/elements/SearchDomains/SearchDomains.tsx
+++ b/src/containers/PageContainer/elements/Header/elements/SearchDomains/SearchDomains.tsx
@@ -48,7 +48,7 @@ export const SearchDomains: React.FC<SearchDomainsProps> = ({
 		<Spring to={{ height: localState.containerHeight || 0 }}>
 			{(animatedStyles) => (
 				<animated.div
-					className="search-domains__results background-primary blur"
+					className="search-domains__results background-primary"
 					style={animatedStyles}
 				>
 					<ul ref={listRef}>

--- a/src/containers/flows/MakeABid/MakeABid.tsx
+++ b/src/containers/flows/MakeABid/MakeABid.tsx
@@ -618,7 +618,7 @@ const MakeABid: React.FC<MakeABidProps> = ({ domain, onBid }) => {
 
 	return (
 		<div
-			className={`${styles.Container} border-primary border-rounded background-primary blur`}
+			className={`${styles.Container} border-primary border-rounded background-primary`}
 		>
 			{header()}
 			<StepBar

--- a/src/containers/flows/MakeABid/MakeABid.tsx
+++ b/src/containers/flows/MakeABid/MakeABid.tsx
@@ -617,7 +617,9 @@ const MakeABid: React.FC<MakeABidProps> = ({ domain, onBid }) => {
 	);
 
 	return (
-		<div className={`${styles.Container} border-primary border-rounded blur`}>
+		<div
+			className={`${styles.Container} border-primary border-rounded background-primary blur`}
+		>
 			{header()}
 			<StepBar
 				step={step + 1}

--- a/src/containers/flows/MintNewNFT/MintNewNFT.tsx
+++ b/src/containers/flows/MintNewNFT/MintNewNFT.tsx
@@ -296,7 +296,9 @@ const MintNewNFT: React.FC<MintNewNFTProps> = ({
 	////////////
 
 	return (
-		<div className={`${styles.MintNewNFT} blur border-rounded border-primary`}>
+		<div
+			className={`${styles.MintNewNFT} blur border-rounded border-primary background-primary`}
+		>
 			{isMintLoading && <div className={styles.Blocker}></div>}
 			{/* // TODO: Pull each section out into a seperate component */}
 			<div className={styles.Header}>

--- a/src/containers/flows/MintNewNFT/MintNewNFT.tsx
+++ b/src/containers/flows/MintNewNFT/MintNewNFT.tsx
@@ -297,7 +297,7 @@ const MintNewNFT: React.FC<MintNewNFTProps> = ({
 
 	return (
 		<div
-			className={`${styles.MintNewNFT} blur border-rounded border-primary background-primary`}
+			className={`${styles.MintNewNFT} border-rounded border-primary background-primary`}
 		>
 			{isMintLoading && <div className={styles.Blocker}></div>}
 			{/* // TODO: Pull each section out into a seperate component */}

--- a/src/containers/legacy/Enlist/Enlist.tsx
+++ b/src/containers/legacy/Enlist/Enlist.tsx
@@ -67,7 +67,7 @@ const Enlist: React.FC<EnlistProps> = ({ onSubmit }) => {
 
 	return (
 		<div
-			className={`${styles.Enlist} blur border-rounded border-primary background-primary`}
+			className={`${styles.Enlist} border-rounded border-primary background-primary`}
 		>
 			<div className={styles.Header}>
 				<h1 className={`glow-text-white`}>Join Waitlist</h1>

--- a/src/containers/legacy/Enlist/Enlist.tsx
+++ b/src/containers/legacy/Enlist/Enlist.tsx
@@ -66,7 +66,9 @@ const Enlist: React.FC<EnlistProps> = ({ onSubmit }) => {
 	}, [enlisting]);
 
 	return (
-		<div className={`${styles.Enlist} blur border-rounded border-primary`}>
+		<div
+			className={`${styles.Enlist} blur border-rounded border-primary background-primary`}
+		>
 			<div className={styles.Header}>
 				<h1 className={`glow-text-white`}>Join Waitlist</h1>
 				<div>

--- a/src/containers/other/NFTView/NFTView.tsx
+++ b/src/containers/other/NFTView/NFTView.tsx
@@ -471,7 +471,7 @@ const NFTView: React.FC<NFTViewProps> = ({ onTransfer }) => {
 
 		return (
 			<section
-				className={`${styles.History} ${styles.Box} blur border-primary border-rounded`}
+				className={`${styles.History} ${styles.Box} blur border-primary border-rounded background-primary`}
 			>
 				<h4>History</h4>
 				{!allItems && (
@@ -539,7 +539,7 @@ const NFTView: React.FC<NFTViewProps> = ({ onTransfer }) => {
 			return (
 				<>
 					<section
-						className={`${styles.Attributes}  blur border-primary border-rounded`}
+						className={`${styles.Attributes}  blur border-primary border-rounded background-primary`}
 					>
 						<div className={styles.AttributesContainer}>
 							<h4>Attributes</h4>
@@ -609,7 +609,7 @@ const NFTView: React.FC<NFTViewProps> = ({ onTransfer }) => {
 			{attributes()}
 			<div className={`${styles.TokenHashContainer}`}>
 				<div
-					className={`${styles.Box} ${styles.Contract} blur border-primary border-rounded`}
+					className={`${styles.Box} ${styles.Contract} blur border-primary border-rounded background-primary`}
 				>
 					<h4>Token Id</h4>
 					<p>
@@ -632,7 +632,7 @@ const NFTView: React.FC<NFTViewProps> = ({ onTransfer }) => {
 					</ArrowLink>
 				</div>
 				<div
-					className={`${styles.Box} ${styles.Contract} blur border-primary border-rounded`}
+					className={`${styles.Box} ${styles.Contract} blur border-primary border-rounded background-primary`}
 				>
 					<h4>IPFS Hash</h4>
 					<p>

--- a/src/containers/other/NFTView/NFTView.tsx
+++ b/src/containers/other/NFTView/NFTView.tsx
@@ -471,7 +471,7 @@ const NFTView: React.FC<NFTViewProps> = ({ onTransfer }) => {
 
 		return (
 			<section
-				className={`${styles.History} ${styles.Box} blur border-primary border-rounded background-primary`}
+				className={`${styles.History} ${styles.Box} border-primary border-rounded background-primary`}
 			>
 				<h4>History</h4>
 				{!allItems && (
@@ -539,7 +539,7 @@ const NFTView: React.FC<NFTViewProps> = ({ onTransfer }) => {
 			return (
 				<>
 					<section
-						className={`${styles.Attributes}  blur border-primary border-rounded background-primary`}
+						className={`${styles.Attributes} border-primary border-rounded background-primary`}
 					>
 						<div className={styles.AttributesContainer}>
 							<h4>Attributes</h4>
@@ -609,7 +609,7 @@ const NFTView: React.FC<NFTViewProps> = ({ onTransfer }) => {
 			{attributes()}
 			<div className={`${styles.TokenHashContainer}`}>
 				<div
-					className={`${styles.Box} ${styles.Contract} blur border-primary border-rounded background-primary`}
+					className={`${styles.Box} ${styles.Contract} border-primary border-rounded background-primary`}
 				>
 					<h4>Token Id</h4>
 					<p>
@@ -632,7 +632,7 @@ const NFTView: React.FC<NFTViewProps> = ({ onTransfer }) => {
 					</ArrowLink>
 				</div>
 				<div
-					className={`${styles.Box} ${styles.Contract} blur border-primary border-rounded background-primary`}
+					className={`${styles.Box} ${styles.Contract} border-primary border-rounded background-primary`}
 				>
 					<h4>IPFS Hash</h4>
 					<p>

--- a/src/containers/other/PageHeader/PageHeader.tsx
+++ b/src/containers/other/PageHeader/PageHeader.tsx
@@ -14,7 +14,9 @@ const PageHeader: React.FC<HeaderProps> = ({ style, children, hideNavBar }) => {
 	return (
 		<>
 			<nav
-				className={`${styles.NavBar} blur ${hideNavBar ? styles.Hidden : ''}`}
+				className={`${styles.NavBar} background-primary blur ${
+					hideNavBar ? styles.Hidden : ''
+				}`}
 				style={style}
 			>
 				{children}

--- a/src/containers/other/PageHeader/PageHeader.tsx
+++ b/src/containers/other/PageHeader/PageHeader.tsx
@@ -14,7 +14,7 @@ const PageHeader: React.FC<HeaderProps> = ({ style, children, hideNavBar }) => {
 	return (
 		<>
 			<nav
-				className={`${styles.NavBar} background-primary blur ${
+				className={`${styles.NavBar} background-primary ${
 					hideNavBar ? styles.Hidden : ''
 				}`}
 				style={style}

--- a/src/containers/other/Request/Request.tsx
+++ b/src/containers/other/Request/Request.tsx
@@ -143,7 +143,7 @@ const Request: React.FC<RequestProps> = ({
 			{isModalOpen && (
 				<Overlay centered open onClose={closeModal}>
 					<div
-						className={`${styles.Confirmation} blur border-primary border-rounded`}
+						className={`${styles.Confirmation} blur border-primary border-rounded background-primary`}
 					>
 						<h2 className="glow-text-white">Are you sure?</h2>
 						<hr className="glow" />

--- a/src/containers/other/Request/Request.tsx
+++ b/src/containers/other/Request/Request.tsx
@@ -143,7 +143,7 @@ const Request: React.FC<RequestProps> = ({
 			{isModalOpen && (
 				<Overlay centered open onClose={closeModal}>
 					<div
-						className={`${styles.Confirmation} blur border-primary border-rounded background-primary`}
+						className={`${styles.Confirmation} border-primary border-rounded background-primary`}
 					>
 						<h2 className="glow-text-white">Are you sure?</h2>
 						<hr className="glow" />


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/dApp-Core-Product-Board-e96437225e264ae8ae8d46ca5f4d7b35?p=6a9d95a5d71b4e8fa615db1a4f25d810)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] Bugfix


## 3. What is the old behaviour?
Elements with the ```blur``` class had a transparency issue on firefox browser.
![Screen-Shot-2022-03-04-at-5-27-02-PM](https://user-images.githubusercontent.com/39112648/157785079-fd85127c-9fe3-450f-a5e3-739c1c5ba5e9.png)


## 4. What is the new behaviour?
Added ```background-primary``` to each element with the blur class

- [x] Tested on firefox

