### PR TITLE
Investigate and resolve ‘Cache data may be lost when replacing domains field of a Query object’ error

### DIFF
--- a/src/lib/providers/SubgraphProvider.tsx
+++ b/src/lib/providers/SubgraphProvider.tsx
@@ -42,7 +42,17 @@ export const SubgraphProvider: React.FC<SubgraphContextProviderType> = ({
 	const apolloClient = React.useMemo(() => {
 		return new ApolloClient({
 			uri: chainIdToSubgraph(chainSelector.selectedChain),
-			cache: new InMemoryCache(),
+			cache: new InMemoryCache({
+				typePolicies: {
+					Query: {
+						fields: {
+							domains: {
+								merge: false,
+							},
+						},
+					},
+				},
+			}),
 		});
 	}, [chainSelector.selectedChain]);
 


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/dApp-Core-Product-Board-e96437225e264ae8ae8d46ca5f4d7b35?p=3d3ca539b413421d9760edf557cce130)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] bug/warning fix


## 3. What is the old behaviour?
Cache data may be loss - existing and incoming 

<img width="1210" alt="Screenshot 2022-03-11 at 11 32 59" src="https://user-images.githubusercontent.com/39112648/157866058-6cc6524c-1a29-4997-a9cf-ef06fab24841.png">

<img width="1421" alt="Screenshot 2022-03-10 at 21 33 34" src="https://user-images.githubusercontent.com/39112648/157866085-4956d876-7c7f-4980-8435-f123da89fbde.png">

## 4. What is the new behaviour?
Warning resolved by adding typePolicies to InMemoryCache

My Findings: 
From my understanding, this warning occurs because there is no explicit id or _id property and in Apollo Client 3 the inMemoryCache does not create a fallback fake identifier to normalise the data.

From [Apollo Docs](https://www.apollographql.com/docs/react/caching/cache-field-behavior/#configuring-merge-functions-for-types-rather-than-fields): 

*If you define a merge function for a field, the cache calls that function whenever the field is about to be written with an incoming value (such as from your GraphQL server). When the write occurs, the field's new value is set to the merge  function's return value, instead of the original incoming value.*

*Your merge function cannot push the incoming array directly onto the existing array. It must instead return a new array to prevent potential errors.*

