### PR TITLE
fix: show bid button by default

### DIFF
--- a/src/containers/Tables/SubdomainTable/SubdomainTableCard.tsx
+++ b/src/containers/Tables/SubdomainTable/SubdomainTableCard.tsx
@@ -37,7 +37,8 @@ const SubdomainTableCard = (props: any) => {
 
 	const { domainMetadata } = useCurrentDomain();
 	const isRootDomain = domain.name.split('.').length <= 2;
-	const isBiddable = isRootDomain || Boolean(domainMetadata?.isBiddable);
+	const isBiddable =
+		isRootDomain || Boolean(domainMetadata?.isBiddable ?? true);
 
 	const [hasUpdated, setHasUpdated] = useState<boolean>(false);
 
@@ -107,14 +108,12 @@ const SubdomainTableCard = (props: any) => {
 						</>
 					)}
 				</div>
-				{isBiddable && (
-					<BidButton
-						glow={account !== undefined && !isOwnedByUser}
-						onClick={onButtonClick}
-					>
-						Bid
-					</BidButton>
-				)}
+				<BidButton
+					glow={account !== undefined && !isOwnedByUser && isBiddable}
+					onClick={onButtonClick}
+				>
+					Bid
+				</BidButton>
 			</div>
 		</NFTCard>
 	);

--- a/src/containers/Tables/SubdomainTable/SubdomainTableRow.tsx
+++ b/src/containers/Tables/SubdomainTable/SubdomainTableRow.tsx
@@ -44,7 +44,8 @@ const SubdomainTableRow = (props: any) => {
 	const [isPriceDataLoading, setIsPriceDataLoading] = useState<boolean>(true);
 
 	const isRootDomain = domain.name.split('.').length <= 2;
-	const isBiddable = isRootDomain || Boolean(domainMetadata?.isBiddable);
+	const isBiddable =
+		isRootDomain || Boolean(domainMetadata?.isBiddable ?? true);
 
 	const isOwnedByUser =
 		account?.toLowerCase() === domain?.owner?.id.toLowerCase();
@@ -221,15 +222,15 @@ const SubdomainTableRow = (props: any) => {
 						disabled={isOwnedByUser || !account}
 						style={{ marginLeft: 'auto', width: 160 }}
 					/>
-				) : isBiddable ? (
+				) : (
 					<BidButton
-						glow={account !== undefined && !isOwnedByUser}
+						glow={account !== undefined && !isOwnedByUser && isBiddable}
 						onClick={onBidButtonClick}
 						style={{ marginLeft: 'auto', width: 160 }}
 					>
 						Make A Bid
 					</BidButton>
-				) : null}
+				)}
 			</td>
 		</tr>
 	);


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/Fix-missing-subdomain-table-buttons-eeba1de0297d4e81a067026823152347)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Bugfix

## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

Bid button wouldn't show up for domains that had `metadata.isBiddable = undefined`.

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

Adjusted logic so that internal `isBiddable` is `isBiddable = is biddable true or undefined`.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
