### PR TITLE
fix(buy-now): Use standardised getMetadata method

### DIFF
--- a/src/containers/flows/BuyNow/index.tsx
+++ b/src/containers/flows/BuyNow/index.tsx
@@ -15,7 +15,7 @@ import { Data } from './BuyNow';
 import { useZnsContracts } from 'lib/contracts';
 import { ERC20 } from 'types';
 import { ethers } from 'ethers';
-import { getMetadata } from 'lib/metadata';
+import useMetadata from 'lib/hooks/useMetadata';
 
 export type BuyNowContainerProps = {
 	domainId: string;
@@ -30,6 +30,7 @@ const BuyNowContainer = ({
 }: BuyNowContainerProps) => {
 	// Hooks
 	const { instance: sdk } = useZnsSdk();
+	const { getMetadata } = useMetadata();
 	const { account, library } = useWeb3React();
 	const { wildPriceUsd } = useCurrency();
 	const { addNotification } = useNotification();

--- a/src/containers/flows/BuyNow/index.tsx
+++ b/src/containers/flows/BuyNow/index.tsx
@@ -15,6 +15,7 @@ import { Data } from './BuyNow';
 import { useZnsContracts } from 'lib/contracts';
 import { ERC20 } from 'types';
 import { ethers } from 'ethers';
+import { getMetadata } from 'lib/metadata';
 
 export type BuyNowContainerProps = {
 	domainId: string;
@@ -143,11 +144,11 @@ const BuyNowContainer = ({
 			console.warn('<BuyNow> Failed to Get Data', e);
 		}
 		try {
-			const [domain, metadata, balance] = await Promise.all([
+			const [domain, balance] = await Promise.all([
 				sdk.getDomainById(domainId),
-				sdk.getDomainMetadata(domainId, library.getSigner()),
 				wildContract.balanceOf(account),
 			]);
+			const metadata = await getMetadata(domain.metadataUri);
 			if (domain && metadata && buyNowPrice && balance) {
 				setData({
 					id: domainId,

--- a/src/containers/flows/SetBuyNow/index.tsx
+++ b/src/containers/flows/SetBuyNow/index.tsx
@@ -13,7 +13,7 @@ import { useZnsSdk } from 'lib/hooks/sdk';
 // Type Imports
 import { DomainData } from './SetBuyNow';
 import { ethers } from 'ethers';
-import { getMetadata } from 'lib/metadata';
+import useMetadata from 'lib/hooks/useMetadata';
 
 export interface SetBuyNowContainerProps {
 	domainId: string;
@@ -31,6 +31,7 @@ const SetBuyNowContainer = ({
 	const { account, library } = useWeb3React();
 	const { wildPriceUsd } = useCurrency();
 	const { addNotification } = useNotification();
+	const { getMetadata } = useMetadata();
 
 	// State
 	const [currentStep, setCurrentStep] = useState<Step>(0);

--- a/src/containers/flows/SetBuyNow/index.tsx
+++ b/src/containers/flows/SetBuyNow/index.tsx
@@ -13,6 +13,7 @@ import { useZnsSdk } from 'lib/hooks/sdk';
 // Type Imports
 import { DomainData } from './SetBuyNow';
 import { ethers } from 'ethers';
+import { getMetadata } from 'lib/metadata';
 
 export interface SetBuyNowContainerProps {
 	domainId: string;
@@ -158,12 +159,12 @@ const SetBuyNowContainer = ({
 		(async () => {
 			setIsLoadingDomainData(true);
 			try {
-				const [domain, events, metadata, price] = await Promise.all([
+				const [domain, events, price] = await Promise.all([
 					sdk.getDomainById(domainId),
 					sdk.getDomainEvents(domainId),
-					sdk.getDomainMetadata(domainId, library.getSigner()),
 					sdk.zauction.getBuyNowPrice(domainId),
 				]);
+				const metadata = await getMetadata(domain.metadataUri);
 				if (domain && events && metadata) {
 					const buyNow = ethers.utils.parseEther(price);
 					checkZAuctionApproval();

--- a/src/lib/hooks/useMetadata.ts
+++ b/src/lib/hooks/useMetadata.ts
@@ -1,0 +1,36 @@
+import { parseDomainMetadata } from 'lib/metadata';
+import { Metadata } from 'lib/types';
+import { useZnsSdk } from './sdk';
+
+type UseMetadataReturn = {
+	getMetadata: (uri: string) => Promise<Metadata | undefined>;
+};
+
+/**
+ * This hook is similar to useDomainMetadata, but
+ * returns a method for getting metadata through the SDK
+ * without using lifecycle methods.
+ *
+ * 30/03/2022
+ * This functionality needs to exist, as currently default values
+ * are not being set in the SDK - for example, domains should be biddable
+ * by default, so isBiddable = undefined should be isBiddable = true
+ *
+ * @returns function for getting metadata through SDK
+ */
+const useMetadata = (): UseMetadataReturn => {
+	const { instance: sdk } = useZnsSdk();
+
+	const getMetadata = async (uri: string) => {
+		const raw = await sdk.utility.getMetadataFromUri(uri);
+		if (raw) {
+			return parseDomainMetadata(raw);
+		}
+	};
+
+	return {
+		getMetadata,
+	};
+};
+
+export default useMetadata;


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/Metadata-not-being-parsed-in-two-spots-b6e0df1465f34ac281d9d72e517e7829)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Bugfix/refactoring

## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

`SetBuyNow` and `BuyNow` modals weren't properly parsing metadata.

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

`SetBuyNow` and `BuyNow` now use `getMetadata` to retrieve metadata.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
