### PR TITLE
refactor: Use context API for SDK use

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import backgroundImage from 'assets/background.jpg';
 //- Page Imports
 import { ZNS, Staking } from 'pages';
 import PageContainer from 'containers/PageContainer';
+import { ZnsSdkProvider } from 'lib/providers/ZnsSdkProvider';
 
 // Web3 library to query
 function getLibrary(provider: any): Web3Provider {
@@ -93,12 +94,14 @@ function wrappedApp() {
 				<ChainSelectorProvider>
 					<SubgraphProvider>
 						<Web3ReactProvider getLibrary={getLibrary}>
-							{/* Our Hooks  */}
-							<MvpVersionProvider>
-								<EnlistProvider>
-									<App />
-								</EnlistProvider>
-							</MvpVersionProvider>
+							<ZnsSdkProvider>
+								{/* Our Hooks  */}
+								<MvpVersionProvider>
+									<EnlistProvider>
+										<App />
+									</EnlistProvider>
+								</MvpVersionProvider>
+							</ZnsSdkProvider>
 						</Web3ReactProvider>
 					</SubgraphProvider>
 				</ChainSelectorProvider>

--- a/src/lib/hooks/sdk/useZnsSdk.tsx
+++ b/src/lib/hooks/sdk/useZnsSdk.tsx
@@ -1,69 +1,7 @@
 import React from 'react';
+import { SdkContext } from 'lib/providers/ZnsSdkProvider';
 
-// Web3 imports
-import { useWeb3React } from '@web3-react/core';
-import { ethers } from 'ethers';
-import { RPC_URLS } from 'lib/connectors';
-import {
-	chainIdToNetworkType,
-	defaultNetworkId,
-	NETWORK_TYPES,
-} from 'lib/network';
-
-// SDK imports
-import * as zns from '@zero-tech/zns-sdk';
-import { useChainSelector } from 'lib/providers/ChainSelectorProvider';
-
-/**
- * Creates a zNS-SDK instance based on the connected wallet
- * and the connected chain ID.
- * If no wallet is connected, it finds our Infura URL for a given
- * network
- * @returns a configured zNS-SDK instance
- */
 export function useZnsSdk() {
-	const { library } = useWeb3React(); // get provider for connected wallet
-	const chainSelector = useChainSelector();
-
-	const instance = React.useMemo(() => {
-		/**
-		 * Use connected wallet's provider if it exists, otherwise create
-		 * a provider using the Infura URL for the selected chain
-		 */
-		const provider =
-			library ||
-			new ethers.providers.JsonRpcProvider(RPC_URLS[defaultNetworkId]);
-		const network = chainIdToNetworkType(chainSelector.selectedChain);
-
-		/**
-		 * Configure the SDK using provider based on selected network
-		 */
-		switch (network) {
-			case NETWORK_TYPES.MAINNET: {
-				return zns.createInstance(
-					zns.configuration.mainnetConfiguration(provider),
-				);
-			}
-
-			case NETWORK_TYPES.RINKEBY: {
-				return zns.createInstance(
-					zns.configuration.rinkebyConfiguration(provider),
-				);
-			}
-
-			case NETWORK_TYPES.KOVAN: {
-				return zns.createInstance(
-					zns.configuration.kovanConfiguration(provider),
-				);
-			}
-
-			default: {
-				throw new Error('SDK isn´t available for this chainId');
-			}
-		}
-	}, [library, chainSelector.selectedChain]);
-
-	return {
-		instance,
-	};
+	const { instance } = React.useContext(SdkContext);
+	return { instance };
 }

--- a/src/lib/providers/ZnsSdkProvider.tsx
+++ b/src/lib/providers/ZnsSdkProvider.tsx
@@ -1,0 +1,70 @@
+import { useWeb3React } from '@web3-react/core';
+import * as zns from '@zero-tech/zns-sdk';
+import React from 'react';
+import { useChainSelector } from 'lib/providers/ChainSelectorProvider';
+import { ethers } from 'ethers';
+import {
+	chainIdToNetworkType,
+	defaultNetworkId,
+	NETWORK_TYPES,
+} from 'lib/network';
+import { RPC_URLS } from 'lib/connectors';
+
+type ZnsSdkProviderProps = {
+	children: React.ReactNode;
+};
+
+export const SdkContext = React.createContext({
+	instance: {} as zns.Instance,
+});
+
+export const ZnsSdkProvider = ({ children }: ZnsSdkProviderProps) => {
+	const { library } = useWeb3React();
+	const chainSelector = useChainSelector();
+
+	const instance = React.useMemo(() => {
+		/**
+		 * Use connected wallet's provider if it exists, otherwise create
+		 * a provider using the Infura URL for the selected chain
+		 */
+		const provider =
+			library ||
+			new ethers.providers.JsonRpcProvider(RPC_URLS[defaultNetworkId]);
+		const network = chainIdToNetworkType(chainSelector.selectedChain);
+
+		/**
+		 * Configure the SDK using provider based on selected network
+		 */
+		switch (network) {
+			case NETWORK_TYPES.MAINNET: {
+				return zns.createInstance(
+					zns.configuration.mainnetConfiguration(provider),
+				);
+			}
+
+			case NETWORK_TYPES.RINKEBY: {
+				return zns.createInstance(
+					zns.configuration.rinkebyConfiguration(provider),
+				);
+			}
+
+			case NETWORK_TYPES.KOVAN: {
+				return zns.createInstance(
+					zns.configuration.kovanConfiguration(provider),
+				);
+			}
+
+			default: {
+				throw new Error('SDK isn´t available for this chainId');
+			}
+		}
+	}, [library, chainSelector.selectedChain]);
+
+	const contextValue = {
+		instance,
+	};
+
+	return (
+		<SdkContext.Provider value={contextValue}>{children}</SdkContext.Provider>
+	);
+};


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/Use-Context-API-for-SDK-9eab3ba31e114d009d5d528567a20e70)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Refactoring

## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

The SDK was just inside a custom hook in a `useMemo`, with the intention of the `useMemo` memo-ising the SDK instance and returning the same object every time it's called. However, creating a new instance of `useZnsSdk` also creates a new instance of the `useMemo`, and so the SDK gets reinitialised.

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

We're using context API for the SDK now so it just gets initialised once, rather than every time it's needed.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
