### PR TITLE
hotfix: Filter Bids in Bid List when used can Accept Bids - Display all by default

### DIFF
--- a/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTableRow.tsx
+++ b/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTableRow.tsx
@@ -94,6 +94,7 @@ const OwnedDomainsTableRow = ({
 						onAccept={refetch}
 						isLoading={isLoadingBidData}
 						highestBid={highestBid?.amount}
+						isAcceptBidEnabled
 					/>
 				</Overlay>
 			);

--- a/src/containers/lists/BidList/BidList.constants.ts
+++ b/src/containers/lists/BidList/BidList.constants.ts
@@ -1,3 +1,3 @@
-export const ALT_TEXT = {
-	QUESTION_MARK: 'Question mark',
+export const MESSAGES = {
+	YOUR_WALLET: ' (Your Ethereum Wallet) ',
 };

--- a/src/containers/lists/BidList/BidList.tsx
+++ b/src/containers/lists/BidList/BidList.tsx
@@ -59,10 +59,11 @@ const BidList: React.FC<BidListProps> = ({
 
 	// Sort bids by date
 	const sortedBids = sortBidsByTime(bids);
-	const filteredBids = sortedBids.filter(
-		(bid) => bid.bidder.toLowerCase() !== account?.toLowerCase(),
-	);
-	const isFilteredBids = isAcceptBidEnabled ? filteredBids : sortedBids;
+	const bidsToShow = isAcceptBidEnabled
+		? sortedBids.filter(
+				(bid) => bid.bidder.toLowerCase() !== account?.toLowerCase(),
+		  )
+		: sortedBids;
 
 	useEffect(() => {
 		if (library) {
@@ -121,7 +122,7 @@ const BidList: React.FC<BidListProps> = ({
 						<p className={styles.Pending}>Accept bid transaction pending.</p>
 					)}
 					<ul className={isAccepting ? styles.Accepting : ''}>
-						{isFilteredBids.map((bid: Bid, i: number) => (
+						{bidsToShow.map((bid: Bid, i: number) => (
 							<li key={bid.bidNonce} className={styles.Bid}>
 								<div>
 									<label>{moment(Number(bid.timestamp)).fromNow()}</label>

--- a/src/containers/lists/BidList/BidList.tsx
+++ b/src/containers/lists/BidList/BidList.tsx
@@ -17,6 +17,9 @@ import { Bid } from '@zero-tech/zauction-sdk';
 import { Domain } from '@zero-tech/zns-sdk/lib/types';
 import { ethers } from 'ethers';
 
+//- Constants Imports
+import { MESSAGES } from './BidList.constants';
+
 //- Library Imports
 import { Metadata } from 'lib/types';
 import { sortBidsByTime } from 'lib/utils/bids';
@@ -32,6 +35,7 @@ type BidListProps = {
 	isAccepting?: boolean;
 	isLoading?: boolean;
 	highestBid?: string;
+	isAcceptBidEnabled?: boolean;
 };
 
 const BidList: React.FC<BidListProps> = ({
@@ -43,6 +47,7 @@ const BidList: React.FC<BidListProps> = ({
 	isAccepting,
 	isLoading,
 	highestBid,
+	isAcceptBidEnabled = false,
 }) => {
 	//////////////////
 	// Data & State //
@@ -50,10 +55,14 @@ const BidList: React.FC<BidListProps> = ({
 	const [blockNumber, setBlockNumber] = useState<number>();
 	const [isAcceptBidModal, setIsAcceptBidModal] = useState(false);
 	const [acceptingBid, setAcceptingBid] = useState<Bid | undefined>(undefined);
-	const { library } = useWeb3React<Web3Provider>();
+	const { library, account } = useWeb3React<Web3Provider>();
 
 	// Sort bids by date
 	const sortedBids = sortBidsByTime(bids);
+	const filteredBids = sortedBids.filter(
+		(bid) => bid.bidder.toLowerCase() !== account?.toLowerCase(),
+	);
+	const isFilteredBids = isAcceptBidEnabled ? filteredBids : sortedBids;
 
 	useEffect(() => {
 		if (library) {
@@ -112,7 +121,7 @@ const BidList: React.FC<BidListProps> = ({
 						<p className={styles.Pending}>Accept bid transaction pending.</p>
 					)}
 					<ul className={isAccepting ? styles.Accepting : ''}>
-						{sortedBids.map((bid: Bid, i: number) => (
+						{isFilteredBids.map((bid: Bid, i: number) => (
 							<li key={bid.bidNonce} className={styles.Bid}>
 								<div>
 									<label>{moment(Number(bid.timestamp)).fromNow()}</label>
@@ -145,6 +154,7 @@ const BidList: React.FC<BidListProps> = ({
 											{bid.bidder.substring(0, 4)}...
 											{bid.bidder.substring(bid.bidder.length - 4)}
 										</a>
+										{account === bid.bidder && MESSAGES.YOUR_WALLET}
 									</span>
 								</div>
 								{blockNumber && (


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Projects-e96437225e264ae8ae8d46ca5f4d7b35?p=fea194c799784b5488ee94c643d879ef)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] Hotfix


## 3. What is the old behaviour?
- User is able to select bids they have made and open the accept bid flow.
- It is not obviously indicated that certain bids are user previous bids


## 4. What is the new behaviour?
- When a user can Accept Bids from the Bid List, we should filter out their own bids.
- When a user is not able to Accept Bids from the Bid List, we should not filter out their own bids.
- Text to indicate users bids

[Loom Walk through](https://www.loom.com/share/c0aef17a67f04b3db2a5815095070a1e)

<img width="1464" alt="Screenshot 2022-04-06 at 13 40 14" src="https://user-images.githubusercontent.com/39112648/161976445-09ab6799-742a-4d84-ab58-8bb356b76d38.png">

