### PR TITLE
fix: add rule to display ‘View Bids’ option when no bids (Profile - Your Domains)

### DIFF
--- a/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTable.constants.ts
+++ b/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTable.constants.ts
@@ -1,6 +1,3 @@
-import settingsIcon from './assets/settings.svg';
-import dollarSignIcon from './assets/dollar-sign.svg';
-
 export const HEADERS = [
 	{
 		label: 'Domain',
@@ -27,14 +24,3 @@ export const ACTION_KEYS = {
 	SETTINGS: 'Domain Settings',
 	VIEW_BIDS: 'View Bids',
 };
-
-export const ACTIONS = [
-	{
-		icon: settingsIcon,
-		title: ACTION_KEYS.SETTINGS,
-	},
-	{
-		icon: dollarSignIcon,
-		title: ACTION_KEYS.VIEW_BIDS,
-	},
-];

--- a/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTable.utils.ts
+++ b/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTable.utils.ts
@@ -1,0 +1,38 @@
+//- Assets Imports
+import settingsIcon from './assets/settings.svg';
+import dollarSignIcon from './assets/dollar-sign.svg';
+
+//- Constants Imports
+import { ACTION_KEYS } from './OwnedDomainsTable.constants';
+
+export const getActions = (isViewBids: boolean) => {
+	const ACTIONS = [
+		{
+			icon: settingsIcon,
+			title: ACTION_KEYS.SETTINGS,
+		},
+		{
+			icon: dollarSignIcon,
+			title: ACTION_KEYS.VIEW_BIDS,
+		},
+	];
+
+	const filteredActions = ACTIONS.filter(
+		(item) => item.title !== ACTION_KEYS.VIEW_BIDS,
+	);
+
+	const actions = isViewBids ? ACTIONS : filteredActions;
+
+	return actions;
+};
+
+export const ACTIONS = [
+	{
+		icon: settingsIcon,
+		title: ACTION_KEYS.SETTINGS,
+	},
+	{
+		icon: dollarSignIcon,
+		title: ACTION_KEYS.VIEW_BIDS,
+	},
+];

--- a/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTableRow.tsx
+++ b/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTableRow.tsx
@@ -27,7 +27,10 @@ import styles from './OwnedDomainsTableRow.module.scss';
 import moreIcon from 'assets/more-vertical.svg';
 
 //- Constants Imports
-import { ACTIONS, ACTION_KEYS } from './OwnedDomainsTable.constants';
+import { ACTION_KEYS } from './OwnedDomainsTable.constants';
+
+//- Utils Imports
+import { getActions } from './OwnedDomainsTable.utils';
 
 enum Modal {
 	ViewBids,
@@ -62,6 +65,8 @@ const OwnedDomainsTableRow = ({
 	const onRowClick = () => {
 		goTo(`/market/${domain.name.split('wilder.')[1]}`);
 	};
+
+	const actions = getActions(bids?.length !== 0);
 
 	const onSelectOption = (option: Option) => {
 		if (option.title === ACTION_KEYS.VIEW_BIDS) {
@@ -146,7 +151,7 @@ const OwnedDomainsTableRow = ({
 				<td>
 					<OptionDropdown
 						onSelect={onSelectOption}
-						options={ACTIONS}
+						options={actions}
 						className={classNames(styles.MoreDropdown)}
 					>
 						<button className={styles.Button}>


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Projects-e96437225e264ae8ae8d46ca5f4d7b35?p=6c6272a340f54080998cb1225b1cdfab)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] Fix


## 3. What is the old behaviour?
Dropdown options include 'View Bids' when there are no bids.


## 4. What is the new behaviour?
Dropdown options include 'View Bids', only when there are bids on the domain.

[Loom Video](https://www.loom.com/share/be83212752854387981806e906b3ad49)