### PR TITLE
feat: Domain table grid card image aspect ratios

### DIFF
--- a/src/components/Cards/ImageCard/ImageCard.module.scss
+++ b/src/components/Cards/ImageCard/ImageCard.module.scss
@@ -8,7 +8,23 @@
 
 	border: 1px solid #232323;
 
-	padding-top: 56.25%;
+	padding-top: 100%;
+
+	background: linear-gradient(
+			to bottom,
+			var(--color-background) 0%,
+			var(--color-background) 100%
+		),
+		linear-gradient(to bottom, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0.5) 100%);
+	background-clip: content-box, padding-box;
+
+	&.Landscape {
+		padding-top: 56.25%;
+	}
+
+	&.Portrait {
+		padding-top: 125%;
+	}
 
 	@media only screen and (max-width: 414px) {
 		min-width: unset;
@@ -19,10 +35,6 @@
 		color: var(--color-text-primary);
 		font-size: 18px;
 		font-weight: 700;
-	}
-
-	.Body {
-		padding: 16px;
 	}
 
 	.Image {
@@ -38,12 +50,6 @@
 		img,
 		video {
 			width: 100%;
-		}
-
-		// This is coupled to the Image component
-		// Should be decoupled
-		div[class*='Spinner'] {
-			margin-top: 100%;
 		}
 	}
 

--- a/src/components/Cards/ImageCard/ImageCard.module.scss
+++ b/src/components/Cards/ImageCard/ImageCard.module.scss
@@ -1,29 +1,40 @@
+$placeholder-background: #000;
+
 .Container {
-	cursor: pointer;
+	--image-card-padding: 100%;
+
 	position: relative !important;
 	min-width: 280px;
-	/* max-width: 388px; */
+
+	background: var(--color-background);
+	border: 1px solid #232323;
 	border-radius: var(--box-radius);
+
+	cursor: pointer;
 	overflow: hidden;
 
-	border: 1px solid #232323;
+	.Body {
+		.Placeholder {
+			position: relative;
+			padding-top: var(--image-card-padding);
+			background: $placeholder-background;
 
-	padding-top: 100%;
-
-	background: linear-gradient(
-			to bottom,
-			var(--color-background) 0%,
-			var(--color-background) 100%
-		),
-		linear-gradient(to bottom, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0.5) 100%);
-	background-clip: content-box, padding-box;
+			.Spinner {
+				display: block;
+				position: absolute;
+				left: 50%;
+				top: 50%;
+				transform: translate(-50%, -50%);
+			}
+		}
+	}
 
 	&.Landscape {
-		padding-top: 56.25%;
+		--image-card-padding: 56.25%;
 	}
 
 	&.Portrait {
-		padding-top: 125%;
+		--image-card-padding: 125%;
 	}
 
 	@media only screen and (max-width: 414px) {
@@ -50,6 +61,11 @@
 		img,
 		video {
 			width: 100%;
+		}
+
+		// Hide default spinner in image
+		div[class*='Spinner'] {
+			display: none;
 		}
 	}
 

--- a/src/components/Cards/ImageCard/ImageCard.tsx
+++ b/src/components/Cards/ImageCard/ImageCard.tsx
@@ -1,5 +1,5 @@
 import styles from './ImageCard.module.scss';
-import { Image, NFTMedia } from 'components';
+import { Image, NFTMedia, Spinner } from 'components';
 import classNames from 'classnames/bind';
 import { AspectRatio } from 'constants/aspectRatios';
 
@@ -37,6 +37,11 @@ const ImageCard = ({
 			onClick={onClick}
 		>
 			<div className={styles.Body}>
+				<div className={styles.Placeholder}>
+					<div className={styles.Spinner}>
+						<Spinner />
+					</div>
+				</div>
 				<div className={styles.Image}>
 					{shouldUseCloudinary ? (
 						<NFTMedia

--- a/src/components/Cards/ImageCard/ImageCard.tsx
+++ b/src/components/Cards/ImageCard/ImageCard.tsx
@@ -1,10 +1,12 @@
 import styles from './ImageCard.module.scss';
 import { Image, NFTMedia } from 'components';
 import classNames from 'classnames/bind';
+import { AspectRatio } from 'constants/aspectRatios';
 
 const cx = classNames.bind(styles);
 
 type ImageCardProps = {
+	aspectRatio?: AspectRatio;
 	children: React.ReactNode;
 	imageUri?: string;
 	header?: string;
@@ -15,6 +17,7 @@ type ImageCardProps = {
 };
 
 const ImageCard = ({
+	aspectRatio,
 	children,
 	header,
 	imageUri,
@@ -23,8 +26,16 @@ const ImageCard = ({
 	className,
 	shouldUseCloudinary,
 }: ImageCardProps) => {
+	const aspectRatioClass = cx({
+		Portrait: aspectRatio === AspectRatio.PORTRAIT,
+		Landscape: aspectRatio === AspectRatio.LANDSCAPE,
+	});
+
 	return (
-		<div className={cx(styles.Container, className)} onClick={onClick}>
+		<div
+			className={cx(styles.Container, className, aspectRatioClass)}
+			onClick={onClick}
+		>
 			<div className={styles.Body}>
 				<div className={styles.Image}>
 					{shouldUseCloudinary ? (

--- a/src/constants/aspectRatios.ts
+++ b/src/constants/aspectRatios.ts
@@ -1,0 +1,13 @@
+export enum AspectRatio {
+	LANDSCAPE = 'landscape', // 16:9
+	PORTRAIT = 'portrait', // 4:5
+}
+
+/**
+ * Hard-coded aspect ratios until we have a better
+ * solution for this
+ */
+export const ASPECT_RATIOS: { [ratio in AspectRatio]: string[] } = {
+	[AspectRatio.LANDSCAPE]: ['wilder.wheels', 'wilder.cribs', 'wilder.craft'],
+	[AspectRatio.PORTRAIT]: ['wilder.WoW'],
+};

--- a/src/containers/Tables/SubdomainTable/SubdomainTableCard.tsx
+++ b/src/containers/Tables/SubdomainTable/SubdomainTableCard.tsx
@@ -8,7 +8,12 @@ import { Web3Provider } from '@ethersproject/providers/lib/web3-provider';
 import useCurrency from 'lib/hooks/useCurrency';
 import { DomainMetrics } from '@zero-tech/zns-sdk/lib/types';
 import { ethers } from 'ethers';
-import { formatNumber, formatEthers } from 'lib/utils';
+import {
+	formatNumber,
+	formatEthers,
+	getParentZna,
+	getAspectRatioForZna,
+} from 'lib/utils';
 
 // Component Imports
 import { Spinner } from 'components';
@@ -81,6 +86,7 @@ const SubdomainTableCard = (props: any) => {
 			imageUri={domainMetadata?.image_full ?? domainMetadata?.image}
 			header={domainMetadata?.title}
 			onClick={onClick}
+			aspectRatio={getAspectRatioForZna(getParentZna(domain.name))}
 		>
 			<div className={styles.Container}>
 				<div className={styles.Bid}>

--- a/src/lib/utils/domains.test.ts
+++ b/src/lib/utils/domains.test.ts
@@ -1,0 +1,41 @@
+import { getAspectRatioForZna, getParentZna } from './domains';
+import { AspectRatio } from 'constants/aspectRatios';
+
+//////////////////////////////
+// f:: getAspectRatioForZna //
+//////////////////////////////
+
+/**
+ * These tests are flaky and could be improved!
+ */
+describe('getAspectRatioForZna', () => {
+	it('should get correct aspect ratio from zNA', () => {
+		expect(getAspectRatioForZna('wilder.wheels')).toBe(AspectRatio.LANDSCAPE);
+		expect(getAspectRatioForZna('wilder.cribs')).toBe(AspectRatio.LANDSCAPE);
+		expect(getAspectRatioForZna('wilder.WoW')).toBe(AspectRatio.PORTRAIT);
+	});
+
+	it('should return undefined if no aspect ratio found', () => {
+		expect(getAspectRatioForZna('')).toBeUndefined();
+	});
+});
+
+//////////////////////
+// f:: getParentZna //
+//////////////////////
+
+describe('getParentZna', () => {
+	it('should get parent zNA', () => {
+		expect(getParentZna('testparent.testchild')).toBe('testparent');
+	});
+
+	it('should get parent zNA from deeply nested zNA', () => {
+		const parent = 'one.two.three.four.five.six.seven.eight.nine';
+		const zna = parent + '.ten';
+		expect(getParentZna(zna)).toBe(parent);
+	});
+
+	it('should handle root zNAs', () => {
+		expect(getParentZna('test')).toBe('test');
+	});
+});

--- a/src/lib/utils/domains.ts
+++ b/src/lib/utils/domains.ts
@@ -1,3 +1,4 @@
+import { AspectRatio, ASPECT_RATIOS } from 'constants/aspectRatios';
 import { ethers } from 'ethers';
 
 export const rootDomainName = 'wilder';
@@ -84,6 +85,41 @@ export const zNAFromPathname = (pathname: string): string => {
 export const appFromPathname = (pathname: string): string => {
 	const matches = pathname.match(/^\/[a-zA-Z]*/);
 	return matches ? matches[0] : '';
+};
+
+/**
+ * Gets zNA of parent, e.g. wilder.wheels.genesis -> wilder.wheels
+ * @param zna to get parent of
+ * @returns zNA of parent, or the original zNA if at root
+ */
+export const getParentZna = (zna: string): string => {
+	if (!zna.includes('.')) {
+		return zna;
+	}
+	return zna.slice(0, zna.lastIndexOf('.'));
+};
+
+/**
+ * Gets a hardcoded aspect ratio for a zNA
+ * @param zna to get aspect ratio for
+ * @returns
+ */
+export const getAspectRatioForZna = (zna: string): AspectRatio | undefined => {
+	if (zna === 'wilder') {
+		return AspectRatio.LANDSCAPE;
+	}
+
+	if (ASPECT_RATIOS[AspectRatio.LANDSCAPE])
+		for (const key in ASPECT_RATIOS) {
+			const znas = ASPECT_RATIOS[key as unknown as AspectRatio];
+			for (var i = 0; i < znas.length; i++) {
+				const z = znas[i];
+				if (zna.startsWith(z)) {
+					return key as AspectRatio;
+				}
+			}
+		}
+	return undefined;
 };
 
 // Truncate domain


### PR DESCRIPTION
_Apologies for the strange wordy title_

<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/In-grid-view-the-images-cover-the-domain-details-2d5a57e2adf84139af148c57564d3520)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Feature

## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

- Grid card aspect ratios weren't being applied
- Grid card loading spinners were incorrectly positioned

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

The two problems in section 3 are now fixed.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->

There's a Loom in the Notion card explaining how to check this!