### PR TITLE
fix: some assets not using Cloudinary

### DIFF
--- a/src/components/Cards/ImageCard/ImageCard.module.scss
+++ b/src/components/Cards/ImageCard/ImageCard.module.scss
@@ -55,7 +55,7 @@ $placeholder-background: #000;
 		position: absolute !important;
 		top: 0;
 		left: 0;
-		height: auto !important;
+		height: 100% !important;
 		width: 100% !important;
 		object-fit: cover;
 

--- a/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTableCard.tsx
+++ b/src/containers/Tables/OwnedDomainsTable/OwnedDomainsTableCard.tsx
@@ -130,6 +130,7 @@ const SubdomainTableCard = ({
 				imageUri={domainMetadata?.image_full ?? domainMetadata?.image}
 				header={domainMetadata?.title}
 				onClick={onClick}
+				shouldUseCloudinary={true}
 			>
 				<div className={styles.Container}>
 					<Detail

--- a/src/containers/Tables/SubdomainTable/SubdomainTableCard.tsx
+++ b/src/containers/Tables/SubdomainTable/SubdomainTableCard.tsx
@@ -89,6 +89,7 @@ const SubdomainTableCard = (props: any) => {
 			header={domainMetadata?.title}
 			onClick={onClick}
 			aspectRatio={getAspectRatioForZna(getParentZna(domain.name))}
+			shouldUseCloudinary={true}
 		>
 			<div className={styles.Container}>
 				<div className={styles.Bid}>


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/neo-In-general-seems-to-be-loading-very-slow-7ac7b2b966754790b875a4a3b23987df)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Bugfix

## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

1. Table cards weren't using Cloudinary, and instead were loading assets straight from IPFS. This was incredibly slow, for obvious reasons.
2. Table card images weren't being vertically aligned.

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

1. Table cards now use Cloudinary to load assets.
2. Table card images are now vertically aligned.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
