### PR TITLE
bug: fix for metadata link in NFT View routing 

### DIFF
--- a/src/components/ArrowLink/ArrowLink.tsx
+++ b/src/components/ArrowLink/ArrowLink.tsx
@@ -13,6 +13,7 @@ type ArrowLinkProps = {
 	replace?: boolean;
 	className?: string;
 	back?: boolean;
+	isLinkToExternalUrl?: boolean;
 };
 
 export const TEST_ID = {
@@ -30,6 +31,7 @@ const ArrowLink: React.FC<ArrowLinkProps> = ({
 	replace,
 	style,
 	back,
+	isLinkToExternalUrl,
 }) => {
 	const content = (
 		<>
@@ -58,7 +60,7 @@ const ArrowLink: React.FC<ArrowLinkProps> = ({
 	 * refactor this in the future.
 	 */
 	return href ? (
-		<Link {...sharedProps} to={href}>
+		<Link {...sharedProps} to={isLinkToExternalUrl ? { pathname: href } : href}>
 			{content}
 		</Link>
 	) : (

--- a/src/containers/other/NFTView/elements/TokenHashBoxes/TokenHashBoxes.tsx
+++ b/src/containers/other/NFTView/elements/TokenHashBoxes/TokenHashBoxes.tsx
@@ -83,6 +83,7 @@ export const TokenHashBoxes: React.FC<TokenHashBoxesProps> = ({
 						width: 150,
 					}}
 					href={etherscanLink}
+					isLinkToExternalUrl
 				>
 					View on Etherscan
 				</ArrowLink>
@@ -104,6 +105,7 @@ export const TokenHashBoxes: React.FC<TokenHashBoxesProps> = ({
 						width: 105,
 					}}
 					href={getWebIPFSUrlFromHash(ipfsHash)}
+					isLinkToExternalUrl
 				>
 					View on IPFS
 				</ArrowLink>


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Projects-e96437225e264ae8ae8d46ca5f4d7b35?p=4bbbcd19ad9045c980f2873d5e094ad0)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] Bug


## 3. What is the old behaviour?
Metadata links on nft view page were not redirecting to correct url


## 4. What is the new behaviour?
Redirect now goes to correct url


https://user-images.githubusercontent.com/39112648/166142824-fbdf296c-ea34-46d0-ad62-8fd4a3155ec2.mov


