### PR TITLE
fix(use-assets): asset totals not summing properly

### DIFF
--- a/src/containers/DAO/pages/DAOPage/hooks/useAssets.ts
+++ b/src/containers/DAO/pages/DAOPage/hooks/useAssets.ts
@@ -37,9 +37,14 @@ const useAssets = (dao?: zDAO): UseAssetsReturn => {
 		try {
 			if (cache[dao[cacheKey]]) {
 				const cached = cache[dao[cacheKey]];
-				setTotalUsd(cached.totalUsd);
-				setAssets(cached.assets);
-				setIsLoading(false);
+				/* Wrapped this in a setTimeout to force it
+					 to run after state is reset above - there
+					 are probably better solutions!	*/
+				setTimeout(() => {
+					setTotalUsd(cached.totalUsd);
+					setAssets(cached.assets);
+					setIsLoading(false);
+				}, 0);
 				return;
 			}
 			dao


### PR DESCRIPTION
When loading asset data from cache, state updates weren't triggering properly in anything consuming useAssets.ts

<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/neo-Bug-Switching-from-grid-to-list-view-on-DAOs-changes-total-amount-in-DAO-summary-Ethan-couldn-3df6a97889634bb7885a723f3e8d14e1)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Bugfix

## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

Steps to recreate bug (on `develop`):
1. Navigate to DAOs <- asset totals are summed correctly
2. Navigate away from DAOs (i.e. to Market)
3. Navigate back to DAOs <- asset totals aren't summed correctly 

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

Asset totals will now sum correctly no matter what context you're arriving from.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
