### PR TITLE
fix: display domain results when searching Wilder

### DIFF
--- a/src/containers/PageContainer/elements/Header/elements/SearchDomains/SearchDomains.constants.ts
+++ b/src/containers/PageContainer/elements/Header/elements/SearchDomains/SearchDomains.constants.ts
@@ -1,5 +1,5 @@
 export const MIN_SEARCH_QUERY_LENGTH = 2;
-export const IS_EXACT_MATCH_ENABLED = true;
+export const IS_EXACT_MATCH_ENABLED = false;
 export const DEFAULT_SEARCH_CONTAINER_PADDING = 24;
 export const DEFAULT_SEARCH_CONTAINER_HEIGHT = 50;
 export const SEARCH_NOT_FOUND = 'No results';

--- a/src/containers/PageContainer/elements/Header/elements/SearchDomains/SearchDomains.tsx
+++ b/src/containers/PageContainer/elements/Header/elements/SearchDomains/SearchDomains.tsx
@@ -2,7 +2,10 @@ import React, { useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Spring, animated } from 'react-spring';
 import { useDomainSearch } from 'lib/useDomainSearch';
-import { SEARCH_NOT_FOUND } from './SearchDomains.constants';
+import {
+	SEARCH_NOT_FOUND,
+	IS_EXACT_MATCH_ENABLED,
+} from './SearchDomains.constants';
 import {
 	useSearchDomainsData,
 	useSearchDomainsHandlers,
@@ -50,6 +53,18 @@ export const SearchDomains: React.FC<SearchDomainsProps> = ({
 				>
 					<div className="search-domains__results-content">
 						<ul ref={listRef}>
+							{IS_EXACT_MATCH_ENABLED && domainSearch?.exactMatch?.name && (
+								<li
+									className="exact__match"
+									key={domainSearch.exactMatch.name}
+									onMouseDown={handlers.handleDomainClick(
+										domainSearch?.exactMatch?.name || '',
+									)}
+								>
+									{getLastDomainName(domainSearch.exactMatch.name)}{' '}
+									<span>{domainSearch.exactMatch.name}</span>
+								</li>
+							)}
 							{domainSearch?.matches
 								?.filter((d) => d.name.length > 1)
 								.map((s, i) => (

--- a/src/lib/useDomainSearch.tsx
+++ b/src/lib/useDomainSearch.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDomainId, rootDomainName } from './utils/domains';
+import { getDomainId } from './utils/domains';
 import { DisplayParentDomain, ParentDomain } from './types';
 import useAsyncEffect from 'use-async-effect';
 import { useZnsSdk } from './hooks/sdk';
@@ -48,9 +48,7 @@ export function useDomainSearch() {
 			}
 		}
 		try {
-			const rawDomains = await sdk.getDomainsByName(
-				`${rootDomainName}.%${pattern}`,
-			);
+			const rawDomains = await sdk.getDomainsByName(pattern);
 
 			let matchesResult: DisplayParentDomain[] = [];
 			const fuzzyMatch = rawDomains.map((item) => {


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Projects-e96437225e264ae8ae8d46ca5f4d7b35?p=31ebe6869b104579b43f917afb4cb1a6)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- bugfix


## 3. What is the old behaviour?
When entering _wilder_ into the search bar no results are displayed. 


## 4. What is the new behaviour?
When entering _wilder_ into the search bar matching results are displayed.
