### PR TITLE
fix: update hover colour for DAO, Staking and Deposit tables

### DIFF
--- a/src/containers/DAO/pages/DAOList/DAOTable/DAOTableRow.module.scss
+++ b/src/containers/DAO/pages/DAOList/DAOTable/DAOTableRow.module.scss
@@ -6,7 +6,7 @@
 	}
 
 	&:hover {
-		background: var(--color-background-alt-50);
+		background: var(--color-revolver);
 	}
 
 	td {

--- a/src/containers/staking/DepositTable/DepositTableRow.module.scss
+++ b/src/containers/staking/DepositTable/DepositTableRow.module.scss
@@ -2,7 +2,7 @@
 	cursor: pointer;
 
 	&:hover {
-		background: var(--color-background-alt-50);
+		background: var(--color-revolver);
 	}
 
 	td {

--- a/src/containers/staking/StakePoolTable/StakePoolTableRow.module.scss
+++ b/src/containers/staking/StakePoolTable/StakePoolTableRow.module.scss
@@ -2,7 +2,7 @@
 	cursor: pointer;
 
 	&:hover {
-		background: var(--color-background-alt-50);
+		background: var(--color-revolver);
 	}
 
 	td {


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Projects-e96437225e264ae8ae8d46ca5f4d7b35?p=3140736db7a142ce994e5d208a9b8995)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] Other - style change


## 3. What is the old behaviour?
DAO, Staking and Deposits table rows had a different background hover colour to market.

## 4. What is the new behaviour?
All table rows now have the correct hover background colour.


## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
