### PR TITLE
fix: Fix broken edit buy now button and modal header

### DIFF
--- a/src/containers/flows/SetBuyNow/SetBuyNow.tsx
+++ b/src/containers/flows/SetBuyNow/SetBuyNow.tsx
@@ -48,15 +48,18 @@ const SetBuyNow = ({
 	account,
 }: SetBuyNowProps) => {
 	const editText = account !== domain?.owner ? 'selecting' : 'purchasing';
+	const getTitle = () =>
+		domain?.currentBuyNowPrice?.gt(0) ? 'Edit Buy Now' : 'Set Buy Now';
+	const wizardHeader = getTitle();
 	if (isLoadingDomainData) {
 		return (
-			<Wizard header="Set Buy Now">
+			<Wizard header={wizardHeader}>
 				<Wizard.Loading message="Loading domain data..." />
 			</Wizard>
 		);
 	} else if (!domain) {
 		return (
-			<Wizard header="Set Buy Now">
+			<Wizard header={wizardHeader}>
 				<Wizard.Confirmation
 					message={'Failed to load domain data'}
 					primaryButtonText={'Cancel'}
@@ -107,7 +110,7 @@ const SetBuyNow = ({
 
 	return (
 		<Wizard
-			header="Set Buy Now"
+			header={wizardHeader}
 			subHeader={`Please review the information and the art to make sure you are ${editText} the right NFT.`}
 		>
 			{steps[step]}

--- a/src/containers/flows/SetBuyNow/SetBuyNow.tsx
+++ b/src/containers/flows/SetBuyNow/SetBuyNow.tsx
@@ -49,7 +49,11 @@ const SetBuyNow = ({
 }: SetBuyNowProps) => {
 	const editText = account !== domain?.owner ? 'selecting' : 'purchasing';
 	const getTitle = () =>
-		domain?.currentBuyNowPrice?.gt(0) ? 'Edit Buy Now' : 'Set Buy Now';
+		isLoadingDomainData
+			? ''
+			: domain?.currentBuyNowPrice?.gt(0)
+			? 'Edit Buy Now'
+			: 'Set Buy Now';
 	const wizardHeader = getTitle();
 	if (isLoadingDomainData) {
 		return (

--- a/src/containers/other/NFTView/NFTView.tsx
+++ b/src/containers/other/NFTView/NFTView.tsx
@@ -205,7 +205,10 @@ const NFTView: React.FC<NFTViewProps> = ({ onTransfer }) => {
 			return openDomainSettings();
 		} else if (option.title === NFT_MORE_ACTIONS_TITLE.TRANSFER_OWNERSHIP) {
 			return onTransfer();
-		} else if (option.title === NFT_MORE_ACTIONS_TITLE.SET_BUY_NOW) {
+		} else if (
+			option.title === NFT_MORE_ACTIONS_TITLE.SET_BUY_NOW ||
+			option.title === NFT_MORE_ACTIONS_TITLE.EDIT_BUY_NOW
+		) {
 			return openSetBuyNow();
 		} else if (option.title === NFT_MORE_ACTIONS_TITLE.VIEW_BIDS) {
 			return openBidList();


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Projects-e96437225e264ae8ae8d46ca5f4d7b35?p=d25cd75bde2544819151d2a5cfc1ea5f)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] bugfix


## 3. What is the old behaviour?
Edit buy now button was broken on NFTView - three dot dropdown option list. 
The modal header was misleading, stating 'Set Buy Now' rather than 'Edit Buy Now'

## 4. What is the new behaviour?
Edit buy now button works as expected.
Modal header will display Edit or Set

