### PR TITLE
fix(current-domain): subdomain loading halting metadata loading

### DIFF
--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -27,12 +27,16 @@ const Preview = ({ title, description, icon, banner, href }: PreviewProps) => {
 					fit="cover"
 				/>
 				<div className={styles.TextContainer}>
-					<h1>{title}</h1>
-					<p>{description}</p>
-					{href && (
-						<ArrowLink className={styles.Link} href={href} replace>
-							View Domain NFT
-						</ArrowLink>
+					{(title || description) && (
+						<>
+							<h1>{title}</h1>
+							<p>{description}</p>
+							{href && (
+								<ArrowLink className={styles.Link} href={href} replace>
+									View Domain NFT
+								</ArrowLink>
+							)}
+						</>
 					)}
 				</div>
 			</div>

--- a/src/containers/cards/CurrentDomainPreview/CurrentDomainPreview.tsx
+++ b/src/containers/cards/CurrentDomainPreview/CurrentDomainPreview.tsx
@@ -2,9 +2,9 @@ import { useCurrentDomain } from 'lib/providers/CurrentDomainProvider';
 import Preview from 'components/Preview/Preview';
 
 const PreviewContainer = () => {
-	const { domain, domainMetadata: metadata } = useCurrentDomain();
+	const { domain, domainMetadata: metadata, domainRaw } = useCurrentDomain();
 
-	if (!metadata || domain?.name === '') {
+	if (domain?.name === '') {
 		return <></>;
 	}
 
@@ -14,7 +14,7 @@ const PreviewContainer = () => {
 			description={metadata?.description}
 			icon={metadata?.previewImage ?? metadata?.image}
 			banner={metadata?.image_full ?? metadata?.image}
-			href={domain?.name && domain.name.split('wilder.')[1] + '?view=true'}
+			href={domainRaw && domainRaw + '?view=true'}
 		/>
 	);
 };


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/Domain-metadata-held-up-on-domains-with-a-lot-of-subdomains-40a861bfd30a456a995b79469fa3103a)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Bugfix

## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

On domains with large subdomains, subdomain loading takes a while. Previously, metadata didn't resolve until all data resolved, so in the case of domains with lots of subdomains, metadata wouldn't show up for a long time.

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

Decoupled the metadata and subdomain loading.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
