### PR TITLE
fix(generic-table): grid view default settings showing list view on mobile for some domains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zns-dapp",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"private": true,
 	"dependencies": {
 		"@apollo/client": "^3.3.13",

--- a/src/components/Tables/GenericTable/GenericTable.tsx
+++ b/src/components/Tables/GenericTable/GenericTable.tsx
@@ -25,17 +25,18 @@ const GenericTable = (props: any) => {
 
 	const isGridViewByDefault = props.isGridViewByDefault;
 
-	const [isGridView, setIsGridView] =
-		usePropsState<boolean>(isGridViewByDefault);
-
 	const [searchQuery, setSearchQuery] = useState<string>();
-
-	const rawData = props.data || [];
-	const chunkSize = isGridView ? 6 : 12;
 
 	const shouldShowViewToggle = props.rowComponent && props.gridComponent;
 	const shouldShowSearchBar = !props.notSearchable && props.data?.length > 0;
 	const isSmallScreen = useMatchMedia(`(max-width: ${GRID_BREAKPOINT}px)`);
+
+	const [isGridView, setIsGridView] = usePropsState<boolean>(
+		!isSmallScreen && isGridViewByDefault,
+	);
+
+	const rawData = props.data || [];
+	const chunkSize = isGridView ? 6 : 12;
 
 	//////////////
 	// Ddata    //


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/Domains-with-grid-by-default-set-to-false-are-showing-list-view-on-mobile-instead-of-grid-0076956b0e094dfe9ab33a62e8b92d78)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Bugfix

## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

- Open http://app.wilderworld.com on small breakpoint
- Navigate to `wilder.wheels.genesis`
- This domain will load in list view despite small breakpoint

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

GenericTable considers screen size when initialising `is grid view`.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
