### PR TITLE
feat: update domain warning message text and conditions

### DIFF
--- a/src/containers/other/NFTView/elements/DomainSettings/DomainSettings.constants.tsx
+++ b/src/containers/other/NFTView/elements/DomainSettings/DomainSettings.constants.tsx
@@ -3,6 +3,7 @@
  */
 export enum DomainSettingsWarning {
 	LOCKED = 'LOCKED',
+	LOCKED_BY = 'LOCKED_BY',
 	TRANSACTION_DENIED = 'TRANSACTION_DENIED',
 	TRANSACTION_FAILED = 'TRANSACTION_FAILED',
 }
@@ -14,6 +15,8 @@ export enum DomainSettingsSuccess {
 
 export const DOMAIN_SETTINGS_WARNING_MESSAGES = {
 	[DomainSettingsWarning.LOCKED]: 'Please unlock to make changes.',
+	[DomainSettingsWarning.LOCKED_BY]:
+		'You cannot unlock the Metadata to make changes as it was locked by ',
 	[DomainSettingsWarning.TRANSACTION_DENIED]: 'Transaction denied by wallet.',
 	[DomainSettingsWarning.TRANSACTION_FAILED]:
 		'Transaction failed, try again later.',

--- a/src/containers/other/NFTView/elements/DomainSettings/DomainSettings.constants.tsx
+++ b/src/containers/other/NFTView/elements/DomainSettings/DomainSettings.constants.tsx
@@ -3,7 +3,6 @@
  */
 export enum DomainSettingsWarning {
 	LOCKED = 'LOCKED',
-	LOCKED_BY = 'LOCKED_BY',
 	TRANSACTION_DENIED = 'TRANSACTION_DENIED',
 	TRANSACTION_FAILED = 'TRANSACTION_FAILED',
 }
@@ -15,8 +14,6 @@ export enum DomainSettingsSuccess {
 
 export const DOMAIN_SETTINGS_WARNING_MESSAGES = {
 	[DomainSettingsWarning.LOCKED]: 'Please unlock to make changes.',
-	[DomainSettingsWarning.LOCKED_BY]:
-		'You cannot unlock the Metadata to make changes as it was locked by ',
 	[DomainSettingsWarning.TRANSACTION_DENIED]: 'Transaction denied by wallet.',
 	[DomainSettingsWarning.TRANSACTION_FAILED]:
 		'Transaction failed, try again later.',
@@ -27,6 +24,9 @@ export const DOMAIN_SETTINGS_SUCCESS_MESSAGES = {
 	[DomainSettingsSuccess.MEATA_DATA_SAVED_AND_LOCKED]:
 		'Your changes have been saved and locked',
 };
+
+export const DOMAIN_SETTINGS_UNLOCKABLE_PROMPT =
+	'You cannot unlock the Metadata to make changes as it was locked by ';
 
 /**
  * Modals
@@ -151,4 +151,15 @@ export const DOMAIN_SETTINGS_TOOLTIPS = {
 		'Grid view has larger image previews which can benefit domains with a focus on art rather than statistics.',
 	[DomainSettingsTooltipType.SETTINGS_CUSTOM_DOMAIN_HEADER]:
 		'Change the first column header of list view. By default this is ‘Domain’.',
+};
+
+/**
+ * Button Labels
+ */
+export const DOMAIN_SETTINGS_INITIAL_BUTTON_LABELS = {
+	LOCK_METADATA: 'Lock Metadata',
+	UNLOCK_METADATA: 'Unlock MetaData',
+	SAVE_CHANGES: 'Save Changes',
+	SAVE_AND_LOCK: 'Save & Lock',
+	FINISH: 'Finish',
 };

--- a/src/containers/other/NFTView/elements/DomainSettings/DomainSettings.tsx
+++ b/src/containers/other/NFTView/elements/DomainSettings/DomainSettings.tsx
@@ -38,6 +38,7 @@ const DomainSettings: React.FC<DomainSettingsProps> = ({
 			library,
 			onClose,
 			setDomainMetadata,
+			domain: formattedData.myDomain.domain,
 		},
 		localState,
 		localActions,
@@ -77,6 +78,7 @@ const DomainSettings: React.FC<DomainSettingsProps> = ({
 					/>
 					{/* Footer */}
 					<DomainSettingsFooter
+						domain={formattedData.myDomain.domain}
 						isLocked={localState.isLocked}
 						isChanged={localState.isChanged}
 						isSaved={localState.isSaved}

--- a/src/containers/other/NFTView/elements/DomainSettings/elements/DomainSettingsFooter/DomainSettingsFooter.tsx
+++ b/src/containers/other/NFTView/elements/DomainSettings/elements/DomainSettingsFooter/DomainSettingsFooter.tsx
@@ -1,7 +1,21 @@
+//-React Imports
 import React, { useMemo } from 'react';
+
+//- Library Improts
+import { Maybe, DisplayDomain } from 'lib/types';
 import classnames from 'classnames';
-import { FutureButton, QuestionButton, Tooltip, IconButton } from 'components';
-import { Maybe } from 'lib/types';
+
+//-Component Imports
+import {
+	FutureButton,
+	QuestionButton,
+	Tooltip,
+	IconButton,
+	Member,
+} from 'components';
+import './_domain-settings-footer.scss';
+
+//- Constants Imports
 import {
 	DomainSettingsWarning,
 	DomainSettingsSuccess,
@@ -10,12 +24,14 @@ import {
 	DomainSettingsTooltipType,
 	DOMAIN_SETTINGS_TOOLTIPS,
 } from '../../DomainSettings.constants';
+
+//- Assets Imports
 import unlockIcon from './assets/unlock.svg';
 import lockIcon from './assets/lock.svg';
 import lockWarningIcon from './assets/lock-warning.svg';
-import './_domain-settings-footer.scss';
 
 type DomainSettingsFooterProps = {
+	domain: Maybe<DisplayDomain>;
 	isLocked: boolean;
 	isChanged: boolean;
 	isSaved: boolean;
@@ -30,6 +46,7 @@ type DomainSettingsFooterProps = {
 };
 
 export const DomainSettingsFooter: React.FC<DomainSettingsFooterProps> = ({
+	domain,
 	isLocked,
 	isChanged,
 	isSaved,
@@ -61,10 +78,17 @@ export const DomainSettingsFooter: React.FC<DomainSettingsFooterProps> = ({
 				{warning && (
 					<label
 						className={classnames('warning', {
-							is_locked_warning: warning === DomainSettingsWarning.LOCKED,
+							is_locked_warning:
+								warning === DomainSettingsWarning.LOCKED ||
+								warning === DomainSettingsWarning.LOCKED_BY,
 						})}
 					>
 						{DOMAIN_SETTINGS_WARNING_MESSAGES[warning]}
+						{warning === DomainSettingsWarning.LOCKED_BY && domain ? (
+							<Member id={domain?.lockedBy.id} />
+						) : (
+							''
+						)}
 					</label>
 				)}
 				{success && (

--- a/src/containers/other/NFTView/elements/DomainSettings/elements/DomainSettingsFooter/DomainSettingsFooter.tsx
+++ b/src/containers/other/NFTView/elements/DomainSettings/elements/DomainSettingsFooter/DomainSettingsFooter.tsx
@@ -23,6 +23,8 @@ import {
 	DOMAIN_SETTINGS_SUCCESS_MESSAGES,
 	DomainSettingsTooltipType,
 	DOMAIN_SETTINGS_TOOLTIPS,
+	DOMAIN_SETTINGS_UNLOCKABLE_PROMPT,
+	DOMAIN_SETTINGS_INITIAL_BUTTON_LABELS,
 } from '../../DomainSettings.constants';
 
 //- Assets Imports
@@ -78,17 +80,20 @@ export const DomainSettingsFooter: React.FC<DomainSettingsFooterProps> = ({
 				{warning && (
 					<label
 						className={classnames('warning', {
-							is_locked_warning:
-								warning === DomainSettingsWarning.LOCKED ||
-								warning === DomainSettingsWarning.LOCKED_BY,
+							is_locked_warning: warning === DomainSettingsWarning.LOCKED,
 						})}
 					>
 						{DOMAIN_SETTINGS_WARNING_MESSAGES[warning]}
-						{warning === DomainSettingsWarning.LOCKED_BY && domain ? (
-							<Member id={domain?.lockedBy.id} />
-						) : (
-							''
-						)}
+					</label>
+				)}
+				{isLocked && domain && !unlockable && (
+					<label
+						className={classnames('warning', {
+							is_locked_warning: !unlockable,
+						})}
+					>
+						{DOMAIN_SETTINGS_UNLOCKABLE_PROMPT}
+						<Member id={domain?.lockedBy.id} />
 					</label>
 				)}
 				{success && (
@@ -115,7 +120,7 @@ export const DomainSettingsFooter: React.FC<DomainSettingsFooterProps> = ({
 						disabled={!unlockable}
 						glow={unlockable}
 					>
-						Unlock MetaData
+						{DOMAIN_SETTINGS_INITIAL_BUTTON_LABELS.UNLOCK_METADATA}
 					</FutureButton>
 				)}
 				{!isLocked && !isSaved && (
@@ -126,28 +131,39 @@ export const DomainSettingsFooter: React.FC<DomainSettingsFooterProps> = ({
 							glow={isChanged}
 							disabled={!isChanged}
 						>
-							Save Changes
+							{DOMAIN_SETTINGS_INITIAL_BUTTON_LABELS.SAVE_CHANGES}
 						</FutureButton>
 						<FutureButton className="" onClick={onSaveAndLock} glow>
-							Save & Lock
+							{DOMAIN_SETTINGS_INITIAL_BUTTON_LABELS.SAVE_AND_LOCK}
 						</FutureButton>
 					</div>
 				)}
 				{!isLocked && isSaved && (
 					<div className="domain-settings-footer__buttons-wrapper">
 						<FutureButton className="" onClick={onLock} glow>
-							Lock Metadata
+							{DOMAIN_SETTINGS_INITIAL_BUTTON_LABELS.LOCK_METADATA}
 						</FutureButton>
 						<FutureButton className="" onClick={onFinish} glow>
-							Finish
+							{DOMAIN_SETTINGS_INITIAL_BUTTON_LABELS.FINISH}
 						</FutureButton>
 					</div>
 				)}
-				{isLocked && isSaved && (
-					<FutureButton className="" onClick={onFinish} glow>
-						Finish
-					</FutureButton>
-				)}
+				{isLocked &&
+					isSaved &&
+					(!warning ? (
+						<FutureButton className="" onClick={onFinish} glow>
+							{DOMAIN_SETTINGS_INITIAL_BUTTON_LABELS.FINISH}
+						</FutureButton>
+					) : (
+						<FutureButton
+							className=""
+							onClick={onUnlock}
+							disabled={!unlockable}
+							glow={unlockable}
+						>
+							{DOMAIN_SETTINGS_INITIAL_BUTTON_LABELS.UNLOCK_METADATA}
+						</FutureButton>
+					))}
 				{tooltipText && (
 					<Tooltip text={tooltipText}>
 						<QuestionButton className="domain-settings-footer__buttons-icon" />

--- a/src/containers/other/NFTView/elements/DomainSettings/elements/DomainSettingsFooter/_domain-settings-footer.scss
+++ b/src/containers/other/NFTView/elements/DomainSettings/elements/DomainSettingsFooter/_domain-settings-footer.scss
@@ -30,6 +30,19 @@
 				color: var(--color-success);
 			}
 		}
+
+		div {
+			display: unset;
+		}
+
+		a {
+			color: var(--color-warning);
+			font-weight: bold;
+
+			&:hover {
+				color: var(--color-warning);
+			}
+		}
 	}
 
 	&__buttons {

--- a/src/containers/other/NFTView/elements/DomainSettings/hooks/useDomainSettingsHandlers.tsx
+++ b/src/containers/other/NFTView/elements/DomainSettings/hooks/useDomainSettingsHandlers.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useCallback } from 'react';
 import { DomainMetadata } from '@zero-tech/zns-sdk/lib/types';
-import { Maybe, Metadata } from 'lib/types';
+import { DisplayParentDomain, Maybe, Metadata } from 'lib/types';
 import { parseDomainMetadata } from 'lib/metadata';
 import { useZnsSdk } from 'lib/hooks/sdk';
 import {
@@ -16,6 +16,7 @@ type UseDomainSettingsHandlersProps = {
 		library: Maybe<Web3Provider>;
 		onClose: () => void;
 		setDomainMetadata: (v: Maybe<Metadata>) => void;
+		domain: Maybe<DisplayParentDomain>;
 	};
 	localState: {
 		localMetadata: Maybe<DomainMetadata>;
@@ -130,8 +131,13 @@ export const useDomainSettingsHandlers = ({
 
 	/* Local Actions */
 	const handleShowingLockedWarning = useCallback(() => {
-		localActions.setWarning(DomainSettingsWarning.LOCKED);
-	}, [localActions]);
+		localActions.setSuccess(undefined);
+		localActions.setWarning(
+			props.domain?.lockedBy.id === props.domain?.owner.id
+				? DomainSettingsWarning.LOCKED
+				: DomainSettingsWarning.LOCKED_BY,
+		);
+	}, [localActions, props]);
 
 	const handleLocalMetadataChange = useCallback(
 		(localMetadata: DomainMetadata) => {

--- a/src/containers/other/NFTView/elements/DomainSettings/hooks/useDomainSettingsHandlers.tsx
+++ b/src/containers/other/NFTView/elements/DomainSettings/hooks/useDomainSettingsHandlers.tsx
@@ -135,7 +135,7 @@ export const useDomainSettingsHandlers = ({
 		localActions.setWarning(
 			props.domain?.lockedBy.id === props.domain?.owner.id
 				? DomainSettingsWarning.LOCKED
-				: DomainSettingsWarning.LOCKED_BY,
+				: undefined,
 		);
 	}, [localActions, props]);
 


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Team-Dash-78b824c0cd0e46c59c19dfe103ae929a?p=fadae80ffe704b338f3edaf9de813c25)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- feature (add on to previous feature)

## 3. What is the old behaviour?
When user can't unlock metadata a warning message is displayed that doesn't provide any detail as to why they can't unlock. 
When locking metadata, the user can click to bring up the warning message but the success message persists.


## 4. What is the new behaviour?
Detailed message is now displayed when the user is unable to unlock the metadata.
Simple message is displayed when the user is able to unlock the metadata but currently locked.
Remove any other messages that are being displayed when warning message is triggered.
Display unlock button after locking and clicking the body of the domain settings modal.
Also extracted some hard coded strings to constants file.

Issue:
<img width="950" alt="Screenshot 2022-05-18 at 12 22 33" src="https://user-images.githubusercontent.com/39112648/169034112-08d1e3e5-cbb6-4e1d-9a78-5a6058a6ba7c.png">

Not able to unlock
<img width="950" alt="Screenshot 2022-05-18 at 13 02 24" src="https://user-images.githubusercontent.com/39112648/169034167-9002cb50-e501-4bb6-be6b-c0e63a889c54.png">

Able to lock
<img width="950" alt="Screenshot 2022-05-18 at 13 02 39" src="https://user-images.githubusercontent.com/39112648/169034208-7a4edd35-09dd-49b5-a5d3-1e46e928d237.png">

