### PR TITLE
feat: enable buy now button on table card - subdomain table

### DIFF
--- a/src/containers/Tables/SubdomainTable/SubdomainTableCard.constants.ts
+++ b/src/containers/Tables/SubdomainTable/SubdomainTableCard.constants.ts
@@ -3,3 +3,7 @@ export const LABELS = {
 	BID: 'Bid',
 	BUY: 'Buy',
 };
+
+export const ERROR = {
+	FAIL_TO_RETRIEVE: 'Failed to get buy now price',
+};

--- a/src/containers/Tables/SubdomainTable/SubdomainTableCard.constants.ts
+++ b/src/containers/Tables/SubdomainTable/SubdomainTableCard.constants.ts
@@ -1,4 +1,5 @@
 export const LABELS = {
 	TOP_BID: 'Top Bid',
 	BID: 'Bid',
+	BUY: 'Buy',
 };

--- a/src/containers/Tables/SubdomainTable/SubdomainTableCard.module.scss
+++ b/src/containers/Tables/SubdomainTable/SubdomainTableCard.module.scss
@@ -45,7 +45,7 @@
 		display: flex;
 	}
 
-	.BidButton {
+	.Button {
 		padding: 0 8px;
 
 		@media only screen and (min-width: #{dimensions.$breakpoint-tablet-s}) {

--- a/src/containers/Tables/SubdomainTable/SubdomainTableCard.tsx
+++ b/src/containers/Tables/SubdomainTable/SubdomainTableCard.tsx
@@ -27,7 +27,7 @@ import { BidButton, BuyNowButton } from 'containers';
 import { useBid } from './BidProvider';
 
 //-Constants Imports
-import { LABELS } from './SubdomainTableCard.constants';
+import { LABELS, ERROR } from './SubdomainTableCard.constants';
 import { ROUTES } from 'constants/routes';
 import { CURRENCY } from 'constants/currency';
 
@@ -83,7 +83,7 @@ const SubdomainTableCard = (props: any) => {
 			}
 		} catch (err) {
 			setIsPriceDataLoading(false);
-			console.log('Failed to get buy now price', err);
+			console.log(ERROR.FAIL_TO_RETRIEVE, err);
 		}
 	};
 

--- a/src/containers/flows/BuyNow/BuyNowButton.tsx
+++ b/src/containers/flows/BuyNow/BuyNowButton.tsx
@@ -23,6 +23,7 @@ interface BuyNowButtonProps {
 	onSuccess?: () => void;
 	style?: React.CSSProperties;
 	isTextButton?: boolean;
+	isLoading?: boolean;
 }
 
 const SetBuyNowButton = ({
@@ -33,6 +34,7 @@ const SetBuyNowButton = ({
 	onSuccess,
 	style,
 	isTextButton,
+	isLoading,
 }: BuyNowButtonProps) => {
 	//- Wallet Data
 	const walletContext = useWeb3React<Web3Provider>();
@@ -74,6 +76,7 @@ const SetBuyNowButton = ({
 					className={className}
 					glow={!disabled}
 					onClick={onClick}
+					loading={isLoading}
 				>
 					{buttonText}
 				</FutureButton>


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Team-Dash-78b824c0cd0e46c59c19dfe103ae929a?p=6c1b4974d3244cfbb31deabc5a2f91e6)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- feature


## 3. What is the old behaviour?
When buy now has been set for a domain, the buy now button was not visible in grid view.


## 4. What is the new behaviour?
When buy now has been set for a domain, the buy now button is now visible in grid view.

