### PR TITLE
fix: Error Handling (flows)

### DIFF
--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,5 +1,5 @@
 export const ERRORS = {
-	REJECTED_WALLET: 'Rejected by wallet.',
+	REJECTED_WALLET: 'Rejected by wallet. Please try again.',
 	DATA_CONSUMED:
 		'The bid you are trying to accept is no longer valid. Please select another bid to accept',
 	PROBLEM_OCCURRED: 'An unexpected problem has occurred. Please try again.',
@@ -9,6 +9,7 @@ export const ERRORS = {
 	LIBRARY_NOT_FOUND: 'Could not find web3 library',
 	FAILED_TO_CHECK_ZAUCTION: 'Failed to check zAuction approval status',
 	FAILED_TO_LOAD_DOMAIN_ID: 'Failed to load domain ID',
+	FAILED_TO_RETRIEVE_BID_DATA: 'Failed to retrieve bid data',
 	FAILED_TO_GET_DATA: 'Failed to Get Data',
 };
 

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -11,6 +11,8 @@ export const ERRORS = {
 	FAILED_TO_LOAD_DOMAIN_ID: 'Failed to load domain ID',
 	FAILED_TO_RETRIEVE_BID_DATA: 'Failed to retrieve bid data',
 	FAILED_TO_GET_DATA: 'Failed to Get Data',
+	INSUFFICIENT_FUNDS_BID:
+		'You don’t have enough WILD to make that large of a bid.',
 };
 
 export const MESSAGES = {

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -8,6 +8,7 @@ export const ERRORS = {
 	LIBRARY: 'Failed to connect with Web3 wallet.',
 	LIBRARY_NOT_FOUND: 'Could not find web3 library',
 	CONSOLE_TEXT: 'Failed to check zAuction approval status',
+	FAILED_TO_LOAD_DOMAIN_ID: 'Failed to load domain ID',
 };
 
 export const MESSAGES = {

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -11,8 +11,6 @@ export const ERRORS = {
 	FAILED_TO_LOAD_DOMAIN_ID: 'Failed to load domain ID',
 	FAILED_TO_RETRIEVE_BID_DATA: 'Failed to retrieve bid data',
 	FAILED_TO_GET_DATA: 'Failed to Get Data',
-	INSUFFICIENT_FUNDS_BID:
-		'You don’t have enough WILD to make that large of a bid.',
 };
 
 export const MESSAGES = {

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -15,5 +15,6 @@ export const ERRORS = {
 
 export const MESSAGES = {
 	TRANSACTION_DENIED: 'denied transaction signature',
+	MESSAGE_DENIED: 'denied message signature',
 	DATA_CONSUMED: 'data already consumed',
 };

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -19,4 +19,5 @@ export const MESSAGES = {
 	TRANSACTION_DENIED: 'denied transaction signature',
 	MESSAGE_DENIED: 'denied message signature',
 	DATA_CONSUMED: 'data already consumed',
+	FAILED_TO_SIGN_BID: 'Failed to sign bid message',
 };

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,0 +1,15 @@
+export const ERRORS = {
+	REJECTED_WALLET: 'Rejected by wallet.',
+	DATA_CONSUMED:
+		'The bid you are trying to accept is no longer valid. Please select another bid to accept',
+	PROBLEM_OCCURRED: 'An unexpected problem has occurred. Please try again.',
+	SIGNATURE: 'Failed to generate signature.',
+	TRANSACTION: 'Transaction failed. Please try again',
+	LIBRARY: 'Failed to connect with Web3 wallet.',
+	CONSOLE_TEXT: 'Failed to check zAuction approval status',
+};
+
+export const MESSAGES = {
+	TRANSACTION_DENIED: 'denied transaction signature',
+	DATA_CONSUMED: 'data already consumed',
+};

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -6,6 +6,7 @@ export const ERRORS = {
 	SIGNATURE: 'Failed to generate signature.',
 	TRANSACTION: 'Transaction failed. Please try again',
 	LIBRARY: 'Failed to connect with Web3 wallet.',
+	LIBRARY_NOT_FOUND: 'Could not find web3 library',
 	CONSOLE_TEXT: 'Failed to check zAuction approval status',
 };
 

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -7,8 +7,9 @@ export const ERRORS = {
 	TRANSACTION: 'Transaction failed. Please try again',
 	LIBRARY: 'Failed to connect with Web3 wallet.',
 	LIBRARY_NOT_FOUND: 'Could not find web3 library',
-	CONSOLE_TEXT: 'Failed to check zAuction approval status',
+	FAILED_TO_CHECK_ZAUCTION: 'Failed to check zAuction approval status',
 	FAILED_TO_LOAD_DOMAIN_ID: 'Failed to load domain ID',
+	FAILED_TO_GET_DATA: 'Failed to Get Data',
 };
 
 export const MESSAGES = {

--- a/src/containers/flows/AcceptBid/AcceptBid.constants.tsx
+++ b/src/containers/flows/AcceptBid/AcceptBid.constants.tsx
@@ -43,21 +43,9 @@ export const STATUS_TEXT = {
 	APPROVED: 'Approved',
 };
 
-export const ERRORS = {
-	SIGNATURE: 'Failed to generate signature.',
-	TRANSACTION: 'Transaction failed. Please try again',
-	LIBRARY: 'Failed to connect with Web3 wallet.',
-	CONSOLE_TEXT: 'Failed to check zAuction approval status',
-	REJECTED_WALLET: 'Rejected by wallet.',
-	DATA_CONSUMED:
-		'The bid you are trying to accept is no longer valid. Please select another bid to accept',
-	PROBLEM_OCCURRED: 'An unexpected problem has occurred. Please try again.',
-};
-
 export const MESSAGES = {
 	TEXT_LOADING: 'Loading Bid Data...',
 	TEXT_FAILED_TO_LOAD: 'Failed to load bid data.',
-	TRANSACTION_DENIED: 'denied transaction signature',
 	TEXT_CONFIRMATION:
 		'This transaction is about to be seared upon the blockchain. There’s no going back.',
 	TEXT_ACCEPT_PROMPT: 'Please accept wallet transaction...',
@@ -68,8 +56,6 @@ export const MESSAGES = {
 		'Waiting for transaction approval. You should receive a request in your wallet.',
 	SUCCESS_CONFIRMATION: 'Success! Bid accepted and ownership transferred',
 	CONFIRM_BID_AMOUNT: 'Are you sure you want to accept a bid of',
-	DATA_CONSUMED: 'data already consumed',
-	INCORRECT_BIDDER: 'recovered incorrect bidder',
 };
 
 export const getConfirmNFTPriceDetails = (

--- a/src/containers/flows/AcceptBid/AcceptBid.constants.tsx
+++ b/src/containers/flows/AcceptBid/AcceptBid.constants.tsx
@@ -51,11 +51,13 @@ export const ERRORS = {
 	REJECTED_WALLET: 'Rejected by wallet.',
 	DATA_CONSUMED:
 		'The bid you are trying to accept is no longer valid. Please select another bid to accept',
+	PROBLEM_OCCURRED: 'An unexpected problem has occurred. Please try again.',
 };
 
 export const MESSAGES = {
 	TEXT_LOADING: 'Loading Bid Data...',
 	TEXT_FAILED_TO_LOAD: 'Failed to load bid data.',
+	TRANSACTION_DENIED: 'denied transaction signature',
 	TEXT_CONFIRMATION:
 		'This transaction is about to be seared upon the blockchain. There’s no going back.',
 	TEXT_ACCEPT_PROMPT: 'Please accept wallet transaction...',

--- a/src/containers/flows/AcceptBid/AcceptBid.tsx
+++ b/src/containers/flows/AcceptBid/AcceptBid.tsx
@@ -22,7 +22,7 @@ import { useZnsSdk } from 'lib/hooks/sdk';
 import { StepContent, Step } from './AcceptBid.types';
 
 //- Utils Imports
-import { getErrorMessage } from 'lib/utils/error';
+import { getDisplayErrorMessage } from 'lib/utils/error';
 
 //- Constants Imports
 import {
@@ -147,9 +147,9 @@ const AcceptBid = ({
 				}
 				setCurrentStep(Step.ConfirmDetails);
 				setStepContent(StepContent.Details);
-			} catch (e) {
+			} catch (e: any) {
 				setStepContent(StepContent.ApproveZAuction);
-				const errorText = getErrorMessage(e);
+				const errorText = getDisplayErrorMessage(e.message);
 				setError(errorText);
 			}
 		})();
@@ -169,9 +169,9 @@ const AcceptBid = ({
 			);
 			setIsTransactionComplete(true);
 			setStepContent(StepContent.Success);
-		} catch (e) {
+		} catch (e: any) {
 			setCurrentStep(Step.ConfirmDetails);
-			const errorText = getErrorMessage(e);
+			const errorText = getDisplayErrorMessage(e.message);
 			setError(errorText);
 			setStepContent(StepContent.Details);
 		}

--- a/src/containers/flows/AcceptBid/AcceptBid.tsx
+++ b/src/containers/flows/AcceptBid/AcceptBid.tsx
@@ -167,7 +167,7 @@ const AcceptBid = ({
 			setStepContent(StepContent.Success);
 		} catch (e) {
 			setCurrentStep(Step.ConfirmDetails);
-			setError(ERRORS.PROBLEM_OCCURRED);
+			setError(e.message);
 			setStepContent(StepContent.Details);
 		}
 		if (!isMounted.current) return;

--- a/src/containers/flows/AcceptBid/AcceptBid.tsx
+++ b/src/containers/flows/AcceptBid/AcceptBid.tsx
@@ -149,8 +149,7 @@ const AcceptBid = ({
 				setStepContent(StepContent.Details);
 			} catch (e: any) {
 				setStepContent(StepContent.ApproveZAuction);
-				const errorText = getDisplayErrorMessage(e.message);
-				setError(errorText);
+				setError(getDisplayErrorMessage(e.message));
 			}
 		})();
 	};
@@ -171,8 +170,7 @@ const AcceptBid = ({
 			setStepContent(StepContent.Success);
 		} catch (e: any) {
 			setCurrentStep(Step.ConfirmDetails);
-			const errorText = getDisplayErrorMessage(e.message);
-			setError(errorText);
+			setError(getDisplayErrorMessage(e.message));
 			setStepContent(StepContent.Details);
 		}
 		if (!isMounted.current) return;

--- a/src/containers/flows/AcceptBid/AcceptBid.tsx
+++ b/src/containers/flows/AcceptBid/AcceptBid.tsx
@@ -24,13 +24,13 @@ import { StepContent, Step } from './AcceptBid.types';
 //- Constants Imports
 import {
 	BUTTONS,
-	ERRORS,
 	getSuccessNotification,
 	MESSAGES,
 	STATUS_TEXT,
 	STEP_BAR_HEADING,
 	STEP_CONTENT_TITLES,
 } from './AcceptBid.constants';
+import { ERRORS } from 'constants/errors';
 
 //- Styles Imports
 import styles from './AcceptBid.module.scss';
@@ -167,7 +167,7 @@ const AcceptBid = ({
 			setStepContent(StepContent.Success);
 		} catch (e) {
 			setCurrentStep(Step.ConfirmDetails);
-			setError(e.message);
+			setError(ERRORS.PROBLEM_OCCURRED);
 			setStepContent(StepContent.Details);
 		}
 		if (!isMounted.current) return;

--- a/src/containers/flows/AcceptBid/AcceptBid.tsx
+++ b/src/containers/flows/AcceptBid/AcceptBid.tsx
@@ -117,7 +117,7 @@ const AcceptBid = ({
 					setStepContent(StepContent.ApproveZAuction);
 				}
 			} catch (e) {
-				console.log(ERRORS.CONSOLE_TEXT);
+				console.log(ERRORS.FAILED_TO_CHECK_ZAUCTION);
 				setCurrentStep(Step.zAuction);
 				setStepContent(StepContent.FailedToCheckZAuction);
 			}
@@ -220,7 +220,7 @@ const AcceptBid = ({
 		[StepContent.FailedToCheckZAuction]: (
 			<Wizard.Confirmation
 				error={error}
-				message={ERRORS.CONSOLE_TEXT}
+				message={ERRORS.FAILED_TO_CHECK_ZAUCTION}
 				primaryButtonText={BUTTONS[StepContent.FailedToCheckZAuction]}
 				onClickPrimaryButton={onClose}
 			/>

--- a/src/containers/flows/AcceptBid/AcceptBid.tsx
+++ b/src/containers/flows/AcceptBid/AcceptBid.tsx
@@ -21,6 +21,9 @@ import { useZnsSdk } from 'lib/hooks/sdk';
 //- Types Imports
 import { StepContent, Step } from './AcceptBid.types';
 
+//- Utils Imports
+import { getErrorMessage } from 'lib/utils/error';
+
 //- Constants Imports
 import {
 	BUTTONS,
@@ -146,7 +149,8 @@ const AcceptBid = ({
 				setStepContent(StepContent.Details);
 			} catch (e) {
 				setStepContent(StepContent.ApproveZAuction);
-				setError(ERRORS.REJECTED_WALLET);
+				const errorText = getErrorMessage(e);
+				setError(errorText);
 			}
 		})();
 	};
@@ -167,7 +171,8 @@ const AcceptBid = ({
 			setStepContent(StepContent.Success);
 		} catch (e) {
 			setCurrentStep(Step.ConfirmDetails);
-			setError(e.message);
+			const errorText = getErrorMessage(e);
+			setError(errorText);
 			setStepContent(StepContent.Details);
 		}
 		if (!isMounted.current) return;

--- a/src/containers/flows/AcceptBid/hooks/useAcceptBid.mocks.ts
+++ b/src/containers/flows/AcceptBid/hooks/useAcceptBid.mocks.ts
@@ -1,0 +1,28 @@
+//- Library Imports
+import { ZAuctionVersionType } from '../AcceptBid.types';
+
+export const mockBidV1 = {
+	bidNonce: '2',
+	bidder: '0x000000000000000000000000',
+	signedMessage: 'message',
+	tokenId: 'id-2',
+	amount: '1000000',
+	timestamp: '0',
+	contract: '0x000000000000000000000000',
+	startBlock: '0',
+	expireBlock: '0',
+	version: ZAuctionVersionType.V1,
+};
+
+export const mockBidV2 = {
+	bidNonce: '1',
+	bidder: '0x000000000000000000000000',
+	signedMessage: 'message',
+	tokenId: 'id-1',
+	amount: '1000000',
+	timestamp: '0',
+	contract: '0x000000000000000000000000',
+	startBlock: '0',
+	expireBlock: '0',
+	version: ZAuctionVersionType.V2,
+};

--- a/src/containers/flows/AcceptBid/hooks/useAcceptBid.test.tsx
+++ b/src/containers/flows/AcceptBid/hooks/useAcceptBid.test.tsx
@@ -7,7 +7,7 @@ import { act } from 'react-dom/test-utils';
 
 //- Constants Imports
 import { MESSAGES } from '../AcceptBid.constants';
-import { ERRORS } from 'constants/errors';
+import * as ERROR_TEXT from 'constants/errors';
 
 //- Hooks Imports
 import useAcceptBid, { UseAcceptBidReturn } from './useAcceptBid';
@@ -111,7 +111,7 @@ test('status updates as expected', async () => {
 });
 
 test('handles failed/rejected signature when data has already been consumed', async () => {
-	mockAcceptBid.mockRejectedValue(new Error('data already consumed'));
+	mockAcceptBid.mockRejectedValue(new Error(ERROR_TEXT.MESSAGES.DATA_CONSUMED));
 	const hook = setupHook();
 
 	var err: Error | undefined;
@@ -124,12 +124,14 @@ test('handles failed/rejected signature when data has already been consumed', as
 	}
 
 	expect(mockAcceptBid).toBeCalledTimes(1);
-	expect(err?.message).toBe(ERRORS.DATA_CONSUMED);
+	expect(err?.message).toBe(ERROR_TEXT.ERRORS.DATA_CONSUMED);
 	expect(console.error).toHaveBeenCalled();
 });
 
 test('handles failed/rejected signature when rejected by wallet', async () => {
-	mockAcceptBid.mockRejectedValue(new Error('Rejected by wallet.'));
+	mockAcceptBid.mockRejectedValue(
+		new Error(ERROR_TEXT.MESSAGES.TRANSACTION_DENIED),
+	);
 	const hook = setupHook();
 
 	var err: Error | undefined;
@@ -142,7 +144,7 @@ test('handles failed/rejected signature when rejected by wallet', async () => {
 	}
 
 	expect(mockAcceptBid).toBeCalledTimes(1);
-	expect(err?.message).toBe(ERRORS.REJECTED_WALLET);
+	expect(err?.message).toBe(ERROR_TEXT.ERRORS.REJECTED_WALLET);
 	expect(console.error).toHaveBeenCalled();
 });
 
@@ -163,6 +165,6 @@ test('handles failed/rejected transaction', async () => {
 	}
 
 	expect(mockTx).toBeCalledTimes(1);
-	expect(err?.message).toBe(ERRORS.TRANSACTION);
+	expect(err?.message).toBe(ERROR_TEXT.ERRORS.TRANSACTION);
 	expect(console.error).toHaveBeenCalled();
 });

--- a/src/containers/flows/AcceptBid/hooks/useAcceptBid.test.tsx
+++ b/src/containers/flows/AcceptBid/hooks/useAcceptBid.test.tsx
@@ -6,7 +6,8 @@ import { render, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 
 //- Constants Imports
-import { MESSAGES, ERRORS } from '../AcceptBid.constants';
+import { MESSAGES } from '../AcceptBid.constants';
+import { ERRORS } from 'constants/errors';
 
 //- Hooks Imports
 import useAcceptBid, { UseAcceptBidReturn } from './useAcceptBid';

--- a/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
+++ b/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
@@ -43,8 +43,7 @@ const useAcceptBid = (): UseAcceptBidReturn => {
 				tx = await sdk.zauction.acceptBid(bid, library.getSigner());
 			} catch (err: any) {
 				console.error(err);
-				const errorText = getDisplayErrorMessage(err.message);
-				throw new Error(errorText);
+				throw new Error(getDisplayErrorMessage(err.message));
 			}
 
 			// Transaction request

--- a/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
+++ b/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
@@ -39,10 +39,13 @@ const useAcceptBid = (): UseAcceptBidReturn => {
 				tx = await sdk.zauction.acceptBid(bid, library.getSigner());
 			} catch (err) {
 				console.error(err);
+				if (err.message.includes(MESSAGES.TRANSACTION_DENIED)) {
+					throw new Error(ERRORS.REJECTED_WALLET);
+				}
 				if (err.message.includes(MESSAGES.DATA_CONSUMED)) {
 					throw new Error(ERRORS.DATA_CONSUMED);
 				}
-				throw new Error(ERRORS.REJECTED_WALLET);
+				throw new Error(ERRORS.PROBLEM_OCCURRED);
 			}
 
 			// Transaction request

--- a/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
+++ b/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
@@ -31,7 +31,7 @@ const useAcceptBid = (): UseAcceptBidReturn => {
 
 	const accept = async (bid: Bid) => {
 		if (!library) {
-			console.error('Could not find web3 library');
+			console.error(ERRORS.LIBRARY_NOT_FOUND);
 			throw new Error(ERRORS.LIBRARY);
 		}
 

--- a/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
+++ b/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
@@ -16,7 +16,7 @@ import { useZnsSdk } from 'lib/hooks/sdk';
 //- Constants Imports
 import { MESSAGES } from '../AcceptBid.constants';
 import { ERRORS } from 'constants/errors';
-import { getError } from 'lib/utils/error';
+import { getErrorMessage } from 'lib/utils/error';
 
 export type UseAcceptBidReturn = {
 	accept: (bid: Bid) => Promise<void>;
@@ -43,7 +43,8 @@ const useAcceptBid = (): UseAcceptBidReturn => {
 				tx = await sdk.zauction.acceptBid(bid, library.getSigner());
 			} catch (err) {
 				console.error(err);
-				getError(err);
+				const errorText = getErrorMessage(err);
+				throw new Error(errorText);
 			}
 
 			// Transaction request
@@ -57,7 +58,8 @@ const useAcceptBid = (): UseAcceptBidReturn => {
 			}
 		} catch (err) {
 			setStatus(undefined);
-			throw err;
+			const errorText = getErrorMessage(err);
+			throw new Error(errorText);
 		}
 	};
 

--- a/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
+++ b/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
@@ -16,7 +16,7 @@ import { useZnsSdk } from 'lib/hooks/sdk';
 //- Constants Imports
 import { MESSAGES } from '../AcceptBid.constants';
 import { ERRORS } from 'constants/errors';
-import { getErrorMessage } from 'lib/utils/error';
+import { getDisplayErrorMessage } from 'lib/utils/error';
 
 export type UseAcceptBidReturn = {
 	accept: (bid: Bid) => Promise<void>;
@@ -41,9 +41,9 @@ const useAcceptBid = (): UseAcceptBidReturn => {
 			let tx;
 			try {
 				tx = await sdk.zauction.acceptBid(bid, library.getSigner());
-			} catch (err) {
+			} catch (err: any) {
 				console.error(err);
-				const errorText = getErrorMessage(err);
+				const errorText = getDisplayErrorMessage(err.message);
 				throw new Error(errorText);
 			}
 
@@ -56,10 +56,9 @@ const useAcceptBid = (): UseAcceptBidReturn => {
 				console.error(err);
 				throw new Error(ERRORS.TRANSACTION);
 			}
-		} catch (err) {
+		} catch (e) {
 			setStatus(undefined);
-			const errorText = getErrorMessage(err);
-			throw new Error(errorText);
+			throw e;
 		}
 	};
 

--- a/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
+++ b/src/containers/flows/AcceptBid/hooks/useAcceptBid.ts
@@ -9,10 +9,14 @@ import { useState } from 'react';
 //- Library Imports
 import { useWeb3React } from '@web3-react/core';
 import { Bid } from '@zero-tech/zauction-sdk';
+
+//- Utils Imports
 import { useZnsSdk } from 'lib/hooks/sdk';
 
 //- Constants Imports
-import { ERRORS, MESSAGES } from '../AcceptBid.constants';
+import { MESSAGES } from '../AcceptBid.constants';
+import { ERRORS } from 'constants/errors';
+import { getError } from 'lib/utils/error';
 
 export type UseAcceptBidReturn = {
 	accept: (bid: Bid) => Promise<void>;
@@ -39,13 +43,7 @@ const useAcceptBid = (): UseAcceptBidReturn => {
 				tx = await sdk.zauction.acceptBid(bid, library.getSigner());
 			} catch (err) {
 				console.error(err);
-				if (err.message.includes(MESSAGES.TRANSACTION_DENIED)) {
-					throw new Error(ERRORS.REJECTED_WALLET);
-				}
-				if (err.message.includes(MESSAGES.DATA_CONSUMED)) {
-					throw new Error(ERRORS.DATA_CONSUMED);
-				}
-				throw new Error(ERRORS.PROBLEM_OCCURRED);
+				getError(err);
 			}
 
 			// Transaction request

--- a/src/containers/flows/BuyNow/BuyNow.tsx
+++ b/src/containers/flows/BuyNow/BuyNow.tsx
@@ -79,8 +79,9 @@ const BuyNow = ({
 			<Wizard.Confirmation
 				error={error}
 				message={'Failed to check zAuction approval status'}
-				primaryButtonText={'Close'}
-				onClickPrimaryButton={onCancel}
+				primaryButtonText={'Retry'}
+				onClickPrimaryButton={onNext}
+				onClickSecondaryButton={onCancel}
 			/>,
 		);
 	}

--- a/src/containers/flows/BuyNow/BuyNow.tsx
+++ b/src/containers/flows/BuyNow/BuyNow.tsx
@@ -6,6 +6,7 @@ import Details from './Steps/Details';
 export enum Step {
 	ApproveZAuction,
 	ApproveZAuctionWaiting,
+	FailedToCheckZAuction,
 	ApproveZAuctionProcessing,
 	Details,
 	WaitingForWalletConfirmation,
@@ -69,6 +70,17 @@ const BuyNow = ({
 				primaryButtonText={'Continue'}
 				onClickSecondaryButton={onCancel}
 				onClickPrimaryButton={onNext}
+			/>,
+		);
+	}
+
+	if (step === Step.FailedToCheckZAuction) {
+		return WrapWizard(
+			<Wizard.Confirmation
+				error={error}
+				message={'Failed to check zAuction approval status'}
+				primaryButtonText={'Close'}
+				onClickPrimaryButton={onCancel}
 			/>,
 		);
 	}

--- a/src/containers/flows/BuyNow/BuyNowButton.constants.ts
+++ b/src/containers/flows/BuyNow/BuyNowButton.constants.ts
@@ -2,3 +2,7 @@ export const LABELS = {
 	PROMPT_TEXT: 'Before you can continue to buy now, you must connect a wallet.',
 	BUTTON_TEXT: 'Set Buy Now',
 };
+
+export const NOTIFICATIONS = {
+	BUY_NOW_SUCCESSFUL: 'You have successfully purchased ',
+};

--- a/src/containers/flows/BuyNow/index.tsx
+++ b/src/containers/flows/BuyNow/index.tsx
@@ -84,8 +84,7 @@ const BuyNowContainer = ({
 				);
 				setCurrentStep(Step.ApproveZAuctionProcessing);
 			} catch (e: any) {
-				const errorText = getDisplayErrorMessage(e.message);
-				throw Error(errorText);
+				throw Error(getDisplayErrorMessage(e.message));
 			}
 
 			try {
@@ -118,7 +117,7 @@ const BuyNowContainer = ({
 				await tx.wait();
 			} catch (e) {
 				setCurrentStep(Step.Details);
-				setError(ERRORS.TRANSACTION);
+				throw Error(ERRORS.TRANSACTION);
 			}
 			addNotification(`${NOTIFICATIONS.BUY_NOW_SUCCESSFUL} ${data?.title}`);
 			setCurrentStep(Step.Success);
@@ -126,9 +125,8 @@ const BuyNowContainer = ({
 				onSuccess();
 			}
 		} catch (e: any) {
-			console.log(e);
-			const errorText = getDisplayErrorMessage(e.message);
-			setError(errorText);
+			console.error(e);
+			setError(getDisplayErrorMessage(e.message));
 			setCurrentStep(Step.Details);
 		}
 	};

--- a/src/containers/flows/BuyNow/index.tsx
+++ b/src/containers/flows/BuyNow/index.tsx
@@ -61,6 +61,10 @@ const BuyNowContainer = ({
 			case Step.ApproveZAuction:
 				approveZAuction();
 				break;
+			case Step.FailedToCheckZAuction:
+				setCurrentStep(Step.ApproveZAuction);
+				setError('');
+				break;
 		}
 	};
 
@@ -94,7 +98,7 @@ const BuyNowContainer = ({
 			getData();
 		} catch (e: any) {
 			setError(e.message);
-			setCurrentStep(Step.ApproveZAuction);
+			setCurrentStep(Step.FailedToCheckZAuction);
 		}
 	};
 

--- a/src/containers/flows/BuyNow/index.tsx
+++ b/src/containers/flows/BuyNow/index.tsx
@@ -18,7 +18,7 @@ import { ethers } from 'ethers';
 import useMetadata from 'lib/hooks/useMetadata';
 
 // Utils Imports
-import { getErrorMessage } from 'lib/utils/error';
+import { getDisplayErrorMessage } from 'lib/utils/error';
 
 // Constants Imports
 import { ERRORS } from 'constants/errors';
@@ -79,8 +79,8 @@ const BuyNowContainer = ({
 					library.getSigner(),
 				);
 				setCurrentStep(Step.ApproveZAuctionProcessing);
-			} catch (e) {
-				const errorText = getErrorMessage(e);
+			} catch (e: any) {
+				const errorText = getDisplayErrorMessage(e.message);
 				throw Error(errorText);
 			}
 
@@ -121,9 +121,9 @@ const BuyNowContainer = ({
 			if (onSuccess) {
 				onSuccess();
 			}
-		} catch (e) {
+		} catch (e: any) {
 			console.log(e);
-			const errorText = getErrorMessage(e);
+			const errorText = getDisplayErrorMessage(e.message);
 			setError(errorText);
 			setCurrentStep(Step.Details);
 		}

--- a/src/containers/flows/BuyNow/index.tsx
+++ b/src/containers/flows/BuyNow/index.tsx
@@ -80,7 +80,8 @@ const BuyNowContainer = ({
 				);
 				setCurrentStep(Step.ApproveZAuctionProcessing);
 			} catch (e) {
-				throw Error(ERRORS.REJECTED_WALLET);
+				const errorText = getErrorMessage(e);
+				throw Error(errorText);
 			}
 
 			try {

--- a/src/containers/flows/CancelBid/CancelBid.constants.ts
+++ b/src/containers/flows/CancelBid/CancelBid.constants.ts
@@ -28,17 +28,9 @@ const BUTTONS = {
 	[Step.Success]: { PRIMARY: 'Finish' },
 };
 
-const ERRORS = {
-	SIGNATURE: 'Failed to generate signature.',
-	TRANSACTION: 'Transaction failed.',
-	LIBRARY: 'Failed to connect with Web3 wallet.',
-	CONSOLE: 'Could not find web3 library',
-};
-
 const exports = {
 	MESSAGES,
 	BUTTONS,
-	ERRORS,
 	LABELS,
 };
 export default exports;

--- a/src/containers/flows/CancelBid/CancelBid.test.tsx
+++ b/src/containers/flows/CancelBid/CancelBid.test.tsx
@@ -17,7 +17,10 @@ import mock from './CancelBid.mock';
 // Other library imports
 import { ethers } from 'ethers';
 import CancelBid from './CancelBid';
+
+// Constants Imports
 import constants from './CancelBid.constants';
+import { ERRORS } from 'constants/errors';
 
 /////////////////////////////
 // Mock external functions //
@@ -232,7 +235,7 @@ test('should handle rejected/failed signature request', async () => {
 
 	screen.getByText(constants.MESSAGES.TEXT_WAITING_FOR_WALLET_V2);
 
-	await screen.findByText(constants.ERRORS.SIGNATURE);
+	await screen.findByText(ERRORS.SIGNATURE);
 
 	expect(console.error).toHaveBeenCalled();
 });
@@ -256,7 +259,7 @@ test('should handle rejected/failed transaction', async () => {
 	screen.getByText(constants.MESSAGES.TEXT_WAITING_FOR_WALLET_V2);
 	await screen.findByText(constants.MESSAGES.TEXT_CANCELLING_BID);
 
-	await screen.findByText(constants.ERRORS.TRANSACTION);
+	await screen.findByText(ERRORS.TRANSACTION);
 
 	expect(console.error).toHaveBeenCalled();
 });

--- a/src/containers/flows/CancelBid/CancelBid.tsx
+++ b/src/containers/flows/CancelBid/CancelBid.tsx
@@ -41,7 +41,6 @@ export const CancelBid = ({
 
 	const onFinish = () => {
 		onClose();
-		onSuccess();
 	};
 
 	const onCancelBid = async () => {
@@ -53,6 +52,7 @@ export const CancelBid = ({
 			setError(e.message);
 			setCurrentStep(Step.Confirmation);
 		}
+		onSuccess();
 	};
 
 	const onBack = () => {

--- a/src/containers/flows/CancelBid/CancelBid.tsx
+++ b/src/containers/flows/CancelBid/CancelBid.tsx
@@ -41,13 +41,13 @@ export const CancelBid = ({
 
 	const onFinish = () => {
 		onClose();
+		onSuccess();
 	};
 
 	const onCancelBid = async () => {
 		setCurrentStep(Step.Cancelling);
 		try {
 			await cancel(bid!);
-			onSuccess();
 			setCurrentStep(Step.Success);
 		} catch (e: any) {
 			setError(e.message);

--- a/src/containers/flows/CancelBid/hooks/useBidData.ts
+++ b/src/containers/flows/CancelBid/hooks/useBidData.ts
@@ -16,6 +16,9 @@ import { getMetadata } from 'lib/metadata';
 import { BigNumber } from 'ethers';
 import { useDidMount } from 'lib/hooks/useDidMount';
 
+//- Constants Imports
+import { ERRORS } from 'constants/errors';
+
 export type UseBidDataReturn = {
 	isLoading: boolean;
 	bid: Bid | undefined;
@@ -52,7 +55,7 @@ const useBidData = (domainId: string, bidNonce: string): UseBidDataReturn => {
 
 		if (!metadata) {
 			setIsLoading(false);
-			throw new Error('Failed to retrieve bid data');
+			throw new Error(ERRORS.FAILED_TO_RETRIEVE_BID_DATA);
 		}
 
 		if (!isMounted.current) {
@@ -81,6 +84,7 @@ const useBidData = (domainId: string, bidNonce: string): UseBidDataReturn => {
 		getData().catch((e) => {
 			console.error(e);
 			setIsLoading(false);
+			throw new Error(ERRORS.FAILED_TO_RETRIEVE_BID_DATA);
 		});
 	};
 

--- a/src/containers/flows/CancelBid/hooks/useBidData.ts
+++ b/src/containers/flows/CancelBid/hooks/useBidData.ts
@@ -84,7 +84,6 @@ const useBidData = (domainId: string, bidNonce: string): UseBidDataReturn => {
 		getData().catch((e) => {
 			console.error(e);
 			setIsLoading(false);
-			throw new Error(ERRORS.FAILED_TO_RETRIEVE_BID_DATA);
 		});
 	};
 

--- a/src/containers/flows/CancelBid/hooks/useCancelBid.test.tsx
+++ b/src/containers/flows/CancelBid/hooks/useCancelBid.test.tsx
@@ -10,6 +10,7 @@ import useCancelBid, { UseCancelBidReturn } from './useCancelBid';
 
 //- Constants Imports
 import constants from '../CancelBid.constants';
+import { ERRORS } from 'constants/errors';
 
 //- Mocks Imports
 import * as mocks from './useCanceBid.mocks';
@@ -118,7 +119,7 @@ describe('useCancelBid', () => {
 			}
 
 			expect(mockCancelBid).toBeCalledTimes(1);
-			expect(err?.message).toBe(constants.ERRORS.SIGNATURE);
+			expect(err?.message).toBe(ERRORS.SIGNATURE);
 			expect(console.error).toHaveBeenCalled();
 		});
 
@@ -139,7 +140,7 @@ describe('useCancelBid', () => {
 			}
 
 			expect(mockTx).toBeCalledTimes(1);
-			expect(err?.message).toBe(constants.ERRORS.TRANSACTION);
+			expect(err?.message).toBe(ERRORS.TRANSACTION);
 			expect(console.error).toHaveBeenCalled();
 		});
 	});
@@ -192,7 +193,7 @@ describe('useCancelBid', () => {
 			}
 
 			expect(mockCancelBid).toBeCalledTimes(1);
-			expect(err?.message).toBe(constants.ERRORS.SIGNATURE);
+			expect(err?.message).toBe(ERRORS.SIGNATURE);
 			expect(console.error).toHaveBeenCalled();
 		});
 
@@ -213,7 +214,7 @@ describe('useCancelBid', () => {
 			}
 
 			expect(mockTx).toBeCalledTimes(1);
-			expect(err?.message).toBe(constants.ERRORS.TRANSACTION);
+			expect(err?.message).toBe(ERRORS.TRANSACTION);
 			expect(console.error).toHaveBeenCalled();
 		});
 	});

--- a/src/containers/flows/CancelBid/hooks/useCancelBid.test.tsx
+++ b/src/containers/flows/CancelBid/hooks/useCancelBid.test.tsx
@@ -10,7 +10,7 @@ import useCancelBid, { UseCancelBidReturn } from './useCancelBid';
 
 //- Constants Imports
 import constants from '../CancelBid.constants';
-import { ERRORS } from 'constants/errors';
+import * as ERROR_TEXT from 'constants/errors';
 
 //- Mocks Imports
 import * as mocks from './useCanceBid.mocks';
@@ -39,6 +39,8 @@ jest.mock('@web3-react/core', () => ({
 		},
 	}),
 }));
+
+const OTHER_ERROR = 'some other error';
 
 ///////////
 // Setup //
@@ -106,7 +108,9 @@ describe('useCancelBid', () => {
 		});
 
 		test('handles failed/rejected signature', async () => {
-			mockCancelBid.mockRejectedValue(undefined);
+			mockCancelBid.mockRejectedValue(
+				new Error(ERROR_TEXT.MESSAGES.MESSAGE_DENIED),
+			);
 			const hook = setupHook();
 
 			var err: Error | undefined;
@@ -119,7 +123,25 @@ describe('useCancelBid', () => {
 			}
 
 			expect(mockCancelBid).toBeCalledTimes(1);
-			expect(err?.message).toBe(ERRORS.SIGNATURE);
+			expect(err?.message).toBe(ERROR_TEXT.ERRORS.REJECTED_WALLET);
+			expect(console.error).toHaveBeenCalled();
+		});
+
+		test('handles "other" errors - generic output', async () => {
+			mockCancelBid.mockRejectedValue(new Error(OTHER_ERROR));
+			const hook = setupHook();
+
+			var err: Error | undefined;
+			try {
+				await act(async () => {
+					await hook.cancel(mocks.mockBidV1);
+				});
+			} catch (e) {
+				err = e as Error;
+			}
+
+			expect(mockCancelBid).toBeCalledTimes(1);
+			expect(err?.message).toBe(ERROR_TEXT.ERRORS.PROBLEM_OCCURRED);
 			expect(console.error).toHaveBeenCalled();
 		});
 
@@ -140,7 +162,7 @@ describe('useCancelBid', () => {
 			}
 
 			expect(mockTx).toBeCalledTimes(1);
-			expect(err?.message).toBe(ERRORS.TRANSACTION);
+			expect(err?.message).toBe(ERROR_TEXT.ERRORS.TRANSACTION);
 			expect(console.error).toHaveBeenCalled();
 		});
 	});
@@ -180,7 +202,9 @@ describe('useCancelBid', () => {
 		});
 
 		test('handles failed/rejected signature', async () => {
-			mockCancelBid.mockRejectedValue(undefined);
+			mockCancelBid.mockRejectedValue(
+				new Error(ERROR_TEXT.MESSAGES.MESSAGE_DENIED),
+			);
 			const hook = setupHook();
 
 			var err: Error | undefined;
@@ -188,12 +212,30 @@ describe('useCancelBid', () => {
 				await act(async () => {
 					await hook.cancel(mocks.mockBidV2);
 				});
-			} catch (e) {
+			} catch (e: any) {
 				err = e as Error;
 			}
 
 			expect(mockCancelBid).toBeCalledTimes(1);
-			expect(err?.message).toBe(ERRORS.SIGNATURE);
+			expect(err?.message).toBe(ERROR_TEXT.ERRORS.REJECTED_WALLET);
+			expect(console.error).toHaveBeenCalled();
+		});
+
+		test('handles "other" errors - generic output', async () => {
+			mockCancelBid.mockRejectedValue(new Error(OTHER_ERROR));
+			const hook = setupHook();
+
+			var err: Error | undefined;
+			try {
+				await act(async () => {
+					await hook.cancel(mocks.mockBidV2);
+				});
+			} catch (e: any) {
+				err = e as Error;
+			}
+
+			expect(mockCancelBid).toBeCalledTimes(1);
+			expect(err?.message).toBe(ERROR_TEXT.ERRORS.PROBLEM_OCCURRED);
 			expect(console.error).toHaveBeenCalled();
 		});
 
@@ -214,7 +256,7 @@ describe('useCancelBid', () => {
 			}
 
 			expect(mockTx).toBeCalledTimes(1);
-			expect(err?.message).toBe(ERRORS.TRANSACTION);
+			expect(err?.message).toBe(ERROR_TEXT.ERRORS.TRANSACTION);
 			expect(console.error).toHaveBeenCalled();
 		});
 	});

--- a/src/containers/flows/CancelBid/hooks/useCancelBid.ts
+++ b/src/containers/flows/CancelBid/hooks/useCancelBid.ts
@@ -58,8 +58,7 @@ const useCancelBid = (): UseCancelBidReturn => {
 				);
 			} catch (e: any) {
 				console.error(e);
-				const errorText = getDisplayErrorMessage(e.message);
-				throw new Error(errorText);
+				throw new Error(getDisplayErrorMessage(e.message));
 			}
 
 			// Transaction request

--- a/src/containers/flows/CancelBid/hooks/useCancelBid.ts
+++ b/src/containers/flows/CancelBid/hooks/useCancelBid.ts
@@ -11,9 +11,13 @@ import { useWeb3React } from '@web3-react/core';
 import { Bid } from '@zero-tech/zauction-sdk';
 import { useZnsSdk } from 'lib/hooks/sdk';
 
+//- Utils Imports
+import { getErrorMessage } from 'lib/utils/error';
+
 //- Constants Imports
 import constants from '../CancelBid.constants';
 import { ZAuctionVersionType } from '../CancelBid.types';
+import { ERRORS } from 'constants/errors';
 
 export type UseCancelBidReturn = {
 	cancel: (bid: Bid) => Promise<void>;
@@ -36,8 +40,8 @@ const useCancelBid = (): UseCancelBidReturn => {
 			bid.version === ZAuctionVersionType.V1 ? false : true;
 
 		if (!library) {
-			console.error(constants.ERRORS.CONSOLE);
-			throw new Error(constants.ERRORS.LIBRARY);
+			console.error(ERRORS.LIBRARY_NOT_FOUND);
+			throw new Error(ERRORS.LIBRARY);
 		}
 
 		try {
@@ -54,7 +58,8 @@ const useCancelBid = (): UseCancelBidReturn => {
 				);
 			} catch (e) {
 				console.error(e);
-				throw new Error(constants.ERRORS.SIGNATURE);
+				const errorText = getErrorMessage(e);
+				throw new Error(errorText);
 			}
 
 			// Transaction request
@@ -64,7 +69,7 @@ const useCancelBid = (): UseCancelBidReturn => {
 				setStatus(undefined);
 			} catch (e) {
 				console.error(e);
-				throw new Error(constants.ERRORS.TRANSACTION);
+				throw new Error(ERRORS.TRANSACTION);
 			}
 		} catch (e) {
 			setStatus(undefined);

--- a/src/containers/flows/CancelBid/hooks/useCancelBid.ts
+++ b/src/containers/flows/CancelBid/hooks/useCancelBid.ts
@@ -12,7 +12,7 @@ import { Bid } from '@zero-tech/zauction-sdk';
 import { useZnsSdk } from 'lib/hooks/sdk';
 
 //- Utils Imports
-import { getErrorMessage } from 'lib/utils/error';
+import { getDisplayErrorMessage } from 'lib/utils/error';
 
 //- Constants Imports
 import constants from '../CancelBid.constants';
@@ -56,9 +56,9 @@ const useCancelBid = (): UseCancelBidReturn => {
 					cancelBidOnChain,
 					library.getSigner(),
 				);
-			} catch (e) {
+			} catch (e: any) {
 				console.error(e);
-				const errorText = getErrorMessage(e);
+				const errorText = getDisplayErrorMessage(e.message);
 				throw new Error(errorText);
 			}
 

--- a/src/containers/flows/MakeABid/MakeABid.constants.tsx
+++ b/src/containers/flows/MakeABid/MakeABid.constants.tsx
@@ -44,6 +44,8 @@ export const MESSAGES = {
 	TEXT_LOADING: 'Loading Domain Data...',
 	ENTER_AMOUNT: 'Enter the amount you wish to bid:',
 	SUCCESSFUL_BID: `Your bid was successfully placed.`,
+	INSUFFICIENT_FUNDS_BID:
+		'You don’t have enough WILD to make that large of a bid.',
 };
 
 export const PLACE_BID_LABELS = {

--- a/src/containers/flows/MakeABid/MakeABid.constants.tsx
+++ b/src/containers/flows/MakeABid/MakeABid.constants.tsx
@@ -31,15 +31,6 @@ export const STEP_CONTENT_TITLES = {
 
 export const STEP_BAR_HEADING = ['zAuction', 'Confirm', 'Place Bid'];
 
-export const ERRORS = {
-	SIGNATURE: 'Failed to generate signature.',
-	TRANSACTION: 'Transaction failed. Please try again.',
-	LIBRARY: 'Failed to connect with Web3 wallet.',
-	CONSOLE_TEXT: 'Failed to check zAuction approval status',
-	REJECTED_WALLET: 'Rejected by wallet. Please try again.',
-	INSUFFICIENT_FUNDS: 'You don’t have enough WILD to make that large of a bid.',
-};
-
 export const STATUS_TEXT = {
 	CHECK_ZAUCTION: 'Checking status of zAuction approval...',
 	ACCEPT_ZAUCTION_PROMPT:

--- a/src/containers/flows/MakeABid/MakeABid.tsx
+++ b/src/containers/flows/MakeABid/MakeABid.tsx
@@ -37,7 +37,7 @@ import { useZnsContracts } from 'lib/contracts';
 import useBidData from './hooks/useBidData';
 
 //- Utils Imports
-import { getErrorMessage } from 'lib/utils/error';
+import { getDisplayErrorMessage } from 'lib/utils/error';
 
 //- Types Imports
 import { Step, StepContent } from './MakeABid.types';
@@ -158,9 +158,9 @@ const MakeABid = ({ domain, onBid, onClose }: MakeABidProps) => {
 				}
 				setCurrentStep(Step.ConfirmDetails);
 				setStepContent(StepContent.Details);
-			} catch (e) {
+			} catch (e: any) {
 				setStepContent(StepContent.ApproveZAuction);
-				const errorText = getErrorMessage(e);
+				const errorText = getDisplayErrorMessage(e.message);
 				setError(errorText);
 			}
 		})();
@@ -192,12 +192,12 @@ const MakeABid = ({ domain, onBid, onClose }: MakeABidProps) => {
 			);
 			setIsBidPlaced(true);
 			setStepContent(StepContent.Success);
-		} catch (e) {
+		} catch (e: any) {
 			if (!isMounted.current) {
 				return;
 			}
 			setCurrentStep(Step.ConfirmDetails);
-			const errorText = getErrorMessage(e);
+			const errorText = getDisplayErrorMessage(e.message);
 			setError(errorText);
 			setStepContent(StepContent.Details);
 		}

--- a/src/containers/flows/MakeABid/MakeABid.tsx
+++ b/src/containers/flows/MakeABid/MakeABid.tsx
@@ -11,7 +11,6 @@ import Details from './components/Details/Details';
 //- Constants Imports
 import {
 	BUTTONS,
-	ERRORS,
 	getBidAmountText,
 	getSuccessNotification,
 	MESSAGES,
@@ -19,6 +18,7 @@ import {
 	STEP_BAR_HEADING,
 	STEP_CONTENT_TITLES,
 } from './MakeABid.constants';
+import { ERRORS } from 'constants/errors';
 
 //- Library Imports
 import { useWeb3React } from '@web3-react/core';
@@ -33,15 +33,18 @@ import { BigNumber, ethers } from 'ethers';
 import { useDidMount } from 'lib/hooks/useDidMount';
 import { useZnsContracts } from 'lib/contracts';
 
-//- Hooks
+//- Hooks Imports
 import useBidData from './hooks/useBidData';
 
-//- Styles Imports
-import styles from './MakeABid.module.scss';
+//- Utils Imports
+import { getErrorMessage } from 'lib/utils/error';
 
 //- Types Imports
 import { Step, StepContent } from './MakeABid.types';
 import { ERC20 } from 'types';
+
+//- Styles Imports
+import styles from './MakeABid.module.scss';
 
 const maxCharacterLength = 28;
 
@@ -122,7 +125,7 @@ const MakeABid = ({ domain, onBid, onClose }: MakeABidProps) => {
 					setStepContent(StepContent.ApproveZAuction);
 				}
 			} catch (e) {
-				console.log(ERRORS.CONSOLE_TEXT);
+				console.log(ERRORS.FAILED_TO_CHECK_ZAUCTION);
 				setCurrentStep(Step.zAuction);
 				setStepContent(StepContent.FailedToCheckZAuction);
 			}
@@ -157,7 +160,8 @@ const MakeABid = ({ domain, onBid, onClose }: MakeABidProps) => {
 				setStepContent(StepContent.Details);
 			} catch (e) {
 				setStepContent(StepContent.ApproveZAuction);
-				setError(ERRORS.REJECTED_WALLET);
+				const errorText = getErrorMessage(e);
+				setError(errorText);
 			}
 		})();
 	};
@@ -193,7 +197,8 @@ const MakeABid = ({ domain, onBid, onClose }: MakeABidProps) => {
 				return;
 			}
 			setCurrentStep(Step.ConfirmDetails);
-			setError(ERRORS.REJECTED_WALLET);
+			const errorText = getErrorMessage(e);
+			setError(errorText);
 			setStepContent(StepContent.Details);
 		}
 	};
@@ -263,7 +268,7 @@ const MakeABid = ({ domain, onBid, onClose }: MakeABidProps) => {
 		[StepContent.FailedToCheckZAuction]: (
 			<Wizard.Confirmation
 				error={error}
-				message={ERRORS.CONSOLE_TEXT}
+				message={ERRORS.FAILED_TO_CHECK_ZAUCTION}
 				primaryButtonText={BUTTONS[StepContent.FailedToCheckZAuction]}
 				onClickPrimaryButton={onClose}
 			/>

--- a/src/containers/flows/MakeABid/MakeABid.tsx
+++ b/src/containers/flows/MakeABid/MakeABid.tsx
@@ -160,8 +160,7 @@ const MakeABid = ({ domain, onBid, onClose }: MakeABidProps) => {
 				setStepContent(StepContent.Details);
 			} catch (e: any) {
 				setStepContent(StepContent.ApproveZAuction);
-				const errorText = getDisplayErrorMessage(e.message);
-				setError(errorText);
+				setError(getDisplayErrorMessage(e.message));
 			}
 		})();
 	};
@@ -197,8 +196,8 @@ const MakeABid = ({ domain, onBid, onClose }: MakeABidProps) => {
 				return;
 			}
 			setCurrentStep(Step.ConfirmDetails);
-			const errorText = getDisplayErrorMessage(e.message);
-			setError(errorText);
+			console.error(e);
+			setError(getDisplayErrorMessage(e.message));
 			setStepContent(StepContent.Details);
 		}
 	};

--- a/src/containers/flows/MakeABid/components/Details/Details.utils.tsx
+++ b/src/containers/flows/MakeABid/components/Details/Details.utils.tsx
@@ -1,6 +1,5 @@
 //- Constants Imports
-import { ERRORS } from 'constants/errors';
-import { getUsdEstimation } from '../../MakeABid.constants';
+import { getUsdEstimation, MESSAGES } from '../../MakeABid.constants';
 
 //- Styles Imports
 import styles from './Details.module.scss';
@@ -23,6 +22,6 @@ export const getBidToHighWarning = (
 	wildBalance: number,
 ) => {
 	if (!isLoading && Number(bid) > wildBalance!) {
-		return <p className={styles.Error}>{ERRORS.INSUFFICIENT_FUNDS_BID}</p>;
+		return <p className={styles.Error}>{MESSAGES.INSUFFICIENT_FUNDS_BID}</p>;
 	}
 };

--- a/src/containers/flows/MakeABid/components/Details/Details.utils.tsx
+++ b/src/containers/flows/MakeABid/components/Details/Details.utils.tsx
@@ -1,5 +1,6 @@
 //- Constants Imports
-import { ERRORS, getUsdEstimation } from '../../MakeABid.constants';
+import { ERRORS } from 'constants/errors';
+import { getUsdEstimation } from '../../MakeABid.constants';
 
 //- Styles Imports
 import styles from './Details.module.scss';
@@ -22,6 +23,6 @@ export const getBidToHighWarning = (
 	wildBalance: number,
 ) => {
 	if (!isLoading && Number(bid) > wildBalance!) {
-		return <p className={styles.Error}>{ERRORS.INSUFFICIENT_FUNDS}</p>;
+		return <p className={styles.Error}>{ERRORS.INSUFFICIENT_FUNDS_BID}</p>;
 	}
 };

--- a/src/containers/flows/MintDropNFT/steps/Approval/Approval.tsx
+++ b/src/containers/flows/MintDropNFT/steps/Approval/Approval.tsx
@@ -70,8 +70,7 @@ const Approval: React.FC<ApprovalProps> = ({
 				}
 			})
 			.catch((e) => {
-				const errorText = getDisplayErrorMessage(e.message);
-				setError(errorText);
+				setError(getDisplayErrorMessage(e.message));
 				setIsWaitingForConfirmation(false);
 				setIsApprovalInProgress(false);
 			});
@@ -89,8 +88,7 @@ const Approval: React.FC<ApprovalProps> = ({
 				}
 			})
 			.catch((e) => {
-				const errorText = getDisplayErrorMessage(e.message);
-				onError(errorText);
+				onError(getDisplayErrorMessage(e.message));
 			});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);

--- a/src/containers/flows/MintDropNFT/steps/Approval/Approval.tsx
+++ b/src/containers/flows/MintDropNFT/steps/Approval/Approval.tsx
@@ -1,16 +1,24 @@
-// Component Imports
-import { FutureButton, Spinner } from 'components';
+//- React Imports
 import React, { useEffect, useState } from 'react';
 
-import { ERC20, WhitelistSimpleSale } from 'types';
-
+//-Component Imports
+import { FutureButton, Spinner } from 'components';
 import {
 	getSaleContractApprovalStatus,
 	approveSaleContract,
 } from '../../helpers';
 
+//- Type Imports
+import { ERC20, WhitelistSimpleSale } from 'types';
+
+//- Library Imports
+import { getDisplayErrorMessage } from 'lib/utils/error';
+
 // Style Imports
 import styles from './Approval.module.scss';
+
+//- Constants Imports
+import { ERRORS } from 'constants/errors';
 
 type ApprovalProps = {
 	contract: WhitelistSimpleSale;
@@ -56,13 +64,14 @@ const Approval: React.FC<ApprovalProps> = ({
 					setHasApproved(true);
 					onApproval();
 				} catch (e: any) {
-					setError(e.message);
+					setError(ERRORS.TRANSACTION);
 					setIsWaitingForConfirmation(false);
 					setIsApprovalInProgress(false);
 				}
 			})
 			.catch((e) => {
-				setError(e.message);
+				const errorText = getDisplayErrorMessage(e.message);
+				setError(errorText);
 				setIsWaitingForConfirmation(false);
 				setIsApprovalInProgress(false);
 			});
@@ -80,7 +89,8 @@ const Approval: React.FC<ApprovalProps> = ({
 				}
 			})
 			.catch((e) => {
-				onError(e.message);
+				const errorText = getDisplayErrorMessage(e.message);
+				onError(errorText);
 			});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);

--- a/src/containers/flows/SetBuyNow/SetBuyNow.constants.ts
+++ b/src/containers/flows/SetBuyNow/SetBuyNow.constants.ts
@@ -1,0 +1,4 @@
+export const NOTIFICATIONS = {
+	SET_BUY_NOW_SUCCESSFUL: 'You have successfully set a Buy Now price of ',
+	REMOVE_BUY_NOW_SUCCESSFUL: 'You have successfully removed the Buy Now price',
+};

--- a/src/containers/flows/SetBuyNow/SetBuyNow.tsx
+++ b/src/containers/flows/SetBuyNow/SetBuyNow.tsx
@@ -4,6 +4,7 @@ import DomainStep from './Steps/DomainStep';
 
 export enum Step {
 	CheckingZAuctionApproval,
+	FailedToCheckZAuction,
 	ApproveZAuction,
 	WaitingForWallet,
 	ApprovingZAuction,
@@ -49,6 +50,8 @@ const SetBuyNow = ({
 }: SetBuyNowProps) => {
 	const editText = account !== domain?.owner ? 'selecting' : 'purchasing';
 
+	const confirmationErrorButtonText = () => (error ? 'Retry' : 'Accept');
+
 	const wizardHeader = isLoadingDomainData
 		? ''
 		: domain?.currentBuyNowPrice?.gt(0)
@@ -76,12 +79,21 @@ const SetBuyNow = ({
 	steps[Step.CheckingZAuctionApproval] = (
 		<Wizard.Loading message="Checking status of zAuction approval..." />
 	);
+	steps[Step.FailedToCheckZAuction] = (
+		<Wizard.Confirmation
+			error={error}
+			message={'Failed to check zAuction approval status'}
+			primaryButtonText="Close"
+			onClickPrimaryButton={onCancel}
+		/>
+	);
 	steps[Step.ApproveZAuction] = (
 		<Wizard.Confirmation
 			error={error}
 			message={
 				'Before you can set a buy now, your wallet needs to approve zAuction. This is a one-off transaction costing gas.'
 			}
+			primaryButtonText={confirmationErrorButtonText()}
 			onClickPrimaryButton={approveZAuction}
 			onClickSecondaryButton={onCancel}
 		/>

--- a/src/containers/flows/SetBuyNow/index.tsx
+++ b/src/containers/flows/SetBuyNow/index.tsx
@@ -211,7 +211,7 @@ const SetBuyNowContainer = ({
 				}
 				setIsLoadingDomainData(false);
 			} catch {
-				console.error('<SetBuyNow> Failed to load domain ID', domainId);
+				console.error(ERRORS.FAILED_TO_LOAD_DOMAIN_ID, domainId);
 				setIsLoadingDomainData(false);
 			}
 		})();

--- a/src/containers/flows/SetBuyNow/index.tsx
+++ b/src/containers/flows/SetBuyNow/index.tsx
@@ -15,9 +15,6 @@ import { DomainData } from './SetBuyNow';
 import { ethers } from 'ethers';
 import useMetadata from 'lib/hooks/useMetadata';
 
-//- Utils Imports
-import { getError } from 'lib/utils/error';
-
 // Constants Imports
 import { MESSAGES, ERRORS } from 'constants/errors';
 
@@ -152,7 +149,11 @@ const SetBuyNowContainer = ({
 			} catch (e) {
 				setCurrentStep(Step.SetBuyNow);
 				console.error(e);
-				getError(e);
+				if (e.message.includes(MESSAGES.TRANSACTION_DENIED)) {
+					setError(ERRORS.REJECTED_WALLET);
+				} else {
+					setError(ERRORS.PROBLEM_OCCURRED);
+				}
 			}
 		})();
 	};

--- a/src/containers/flows/SetBuyNow/index.tsx
+++ b/src/containers/flows/SetBuyNow/index.tsx
@@ -15,6 +15,12 @@ import { DomainData } from './SetBuyNow';
 import { ethers } from 'ethers';
 import useMetadata from 'lib/hooks/useMetadata';
 
+//- Utils Imports
+import { getError } from 'lib/utils/error';
+
+// Constants Imports
+import { MESSAGES, ERRORS } from 'constants/errors';
+
 export interface SetBuyNowContainerProps {
 	domainId: string;
 	onCancel: () => void;
@@ -67,7 +73,7 @@ const SetBuyNowContainer = ({
 				}
 			} catch (e) {
 				// @todo handle error
-				console.error('Failed to check zAuction approval status', e);
+				console.error(ERRORS.CONSOLE_TEXT, e);
 			}
 		})();
 	};
@@ -145,8 +151,8 @@ const SetBuyNowContainer = ({
 				}
 			} catch (e) {
 				setCurrentStep(Step.SetBuyNow);
-				setError((e as any).message);
-				console.log('Error setting buy now price', e);
+				console.error(e);
+				getError(e);
 			}
 		})();
 	};

--- a/src/containers/flows/SetBuyNow/index.tsx
+++ b/src/containers/flows/SetBuyNow/index.tsx
@@ -104,8 +104,7 @@ const SetBuyNowContainer = ({
 				setCurrentStep(Step.SetBuyNow);
 			} catch (e: any) {
 				setCurrentStep(Step.ApproveZAuction);
-				const errorText = getDisplayErrorMessage(e.message);
-				setError(errorText);
+				setError(getDisplayErrorMessage(e.message));
 				console.error(e);
 			}
 		})();
@@ -145,7 +144,7 @@ const SetBuyNowContainer = ({
 					}
 				} catch (e) {
 					setCurrentStep(Step.SetBuyNow);
-					setError(ERRORS.TRANSACTION);
+					throw Error(ERRORS.TRANSACTION);
 				}
 
 				setDomainData({
@@ -169,8 +168,7 @@ const SetBuyNowContainer = ({
 			} catch (e: any) {
 				setCurrentStep(Step.SetBuyNow);
 				console.error(e);
-				const errorText = getDisplayErrorMessage(e.message);
-				setError(errorText);
+				setError(getDisplayErrorMessage(e.message));
 			}
 		})();
 	};

--- a/src/containers/flows/SetBuyNow/index.tsx
+++ b/src/containers/flows/SetBuyNow/index.tsx
@@ -73,7 +73,7 @@ const SetBuyNowContainer = ({
 					setCurrentStep(Step.ApproveZAuction);
 				}
 			} catch (e) {
-				console.error(ERRORS.CONSOLE_TEXT, e);
+				console.error(ERRORS.FAILED_TO_CHECK_ZAUCTION, e);
 				setCurrentStep(Step.FailedToCheckZAuction);
 			}
 		})();

--- a/src/containers/flows/SetBuyNow/index.tsx
+++ b/src/containers/flows/SetBuyNow/index.tsx
@@ -16,7 +16,7 @@ import { ethers } from 'ethers';
 import useMetadata from 'lib/hooks/useMetadata';
 
 //- Utils Imports
-import { getErrorMessage } from 'lib/utils/error';
+import { getDisplayErrorMessage } from 'lib/utils/error';
 
 // Constants Imports
 import { ERRORS } from 'constants/errors';
@@ -102,9 +102,9 @@ const SetBuyNowContainer = ({
 					setError(ERRORS.TRANSACTION);
 				}
 				setCurrentStep(Step.SetBuyNow);
-			} catch (e) {
+			} catch (e: any) {
 				setCurrentStep(Step.ApproveZAuction);
-				const errorText = getErrorMessage(e);
+				const errorText = getDisplayErrorMessage(e.message);
 				setError(errorText);
 				console.error(e);
 			}
@@ -166,10 +166,10 @@ const SetBuyNowContainer = ({
 				if (onSuccess) {
 					onSuccess();
 				}
-			} catch (e) {
+			} catch (e: any) {
 				setCurrentStep(Step.SetBuyNow);
 				console.error(e);
-				const errorText = getErrorMessage(e);
+				const errorText = getDisplayErrorMessage(e.message);
 				setError(errorText);
 			}
 		})();

--- a/src/containers/flows/SetBuyNow/index.tsx
+++ b/src/containers/flows/SetBuyNow/index.tsx
@@ -121,7 +121,6 @@ const SetBuyNowContainer = ({
 				setCurrentStep(Step.WaitingForBuyNowConfirmation);
 				let tx;
 				if (amount) {
-					console.log('setting buy now', amount);
 					tx = await sdk.zauction.setBuyNowPrice(
 						{
 							amount: ethers.utils.parseEther(amount.toString()).toString(),
@@ -130,7 +129,6 @@ const SetBuyNowContainer = ({
 						library.getSigner(),
 					);
 				} else {
-					console.log('cancelling buy now');
 					tx = await sdk.zauction.cancelBuyNow(domainId, library.getSigner());
 				}
 				setCurrentStep(Step.SettingBuyNow);

--- a/src/containers/flows/TransferOwnership/TransferOwnership.tsx
+++ b/src/containers/flows/TransferOwnership/TransferOwnership.tsx
@@ -90,8 +90,7 @@ const TransferOwnership = ({
 				onClose,
 			});
 		} catch (e: any) {
-			const errorText = getDisplayErrorMessage(e.message);
-			setError(errorText);
+			setError(getDisplayErrorMessage(e.message));
 		}
 		if (!isMounted.current) return;
 		setIsLoading(false);

--- a/src/containers/flows/TransferOwnership/TransferOwnership.tsx
+++ b/src/containers/flows/TransferOwnership/TransferOwnership.tsx
@@ -90,7 +90,8 @@ const TransferOwnership = ({
 				onClose,
 			});
 		} catch (e: any) {
-			setError(e.message);
+			const errorText = getDisplayErrorMessage(e.message);
+			setError(errorText);
 		}
 		if (!isMounted.current) return;
 		setIsLoading(false);

--- a/src/containers/flows/TransferOwnership/TransferOwnership.tsx
+++ b/src/containers/flows/TransferOwnership/TransferOwnership.tsx
@@ -15,6 +15,7 @@ import { BUTTONS, MESSAGES, STEP_TITLES } from './TransferOwnership.constants';
 
 //- Utils Imports
 import { isValid } from './TransferOwnership.utils';
+import { getDisplayErrorMessage } from 'lib/utils/error';
 
 //- Library Imports
 import { useTransfer } from 'lib/hooks/useTransfer';
@@ -88,8 +89,8 @@ const TransferOwnership = ({
 				walletAddress,
 				onClose,
 			});
-		} catch (e) {
-			setError(MESSAGES.TRANSACTION_ERROR);
+		} catch (e: any) {
+			setError(e.message);
 		}
 		if (!isMounted.current) return;
 		setIsLoading(false);

--- a/src/lib/hooks/useBidProvider.tsx
+++ b/src/lib/hooks/useBidProvider.tsx
@@ -12,6 +12,7 @@ import { useZnsSdk } from 'lib/hooks/sdk';
 import { Bid as zAuctionBid } from '@zero-tech/zauction-sdk/lib/api/types';
 import { PlaceBidStatus } from '@zero-tech/zauction-sdk';
 import { Web3Provider } from '@ethersproject/providers';
+import { ERRORS, MESSAGES } from 'constants/errors';
 
 /////////////////////
 // Mock data stuff //
@@ -202,11 +203,11 @@ export const useBidProvider = (): UseBidProviderReturn => {
 	const placeBid = useCallback(
 		async (domain: Domain, bid: number, onStep: (status: string) => void) => {
 			if (sdk?.zauction === undefined) {
-				console.warn('No zAuctionInstance');
+				console.warn(ERRORS.FAILED_TO_CHECK_ZAUCTION);
 				return;
 			}
 			if (!library) {
-				console.error('Could not find web3 library');
+				console.error(ERRORS.LIBRARY_NOT_FOUND);
 				return;
 			}
 
@@ -222,7 +223,7 @@ export const useBidProvider = (): UseBidProviderReturn => {
 				onStep('Generating bid...');
 			} catch (e) {
 				console.warn(e);
-				throw new Error('Rejected by wallet');
+				throw new Error(MESSAGES.MESSAGE_DENIED);
 			}
 		},
 		[sdk, library],

--- a/src/lib/hooks/useBidProvider.tsx
+++ b/src/lib/hooks/useBidProvider.tsx
@@ -203,17 +203,14 @@ export const useBidProvider = (): UseBidProviderReturn => {
 	const placeBid = useCallback(
 		async (domain: Domain, bid: number, onStep: (status: string) => void) => {
 			if (sdk?.zauction === undefined) {
-				console.warn(ERRORS.FAILED_TO_CHECK_ZAUCTION);
-				return;
+				throw Error(ERRORS.FAILED_TO_CHECK_ZAUCTION);
 			}
 			if (!library) {
-				console.error(ERRORS.LIBRARY_NOT_FOUND);
-				return;
+				throw Error(ERRORS.LIBRARY_NOT_FOUND);
 			}
 
 			if (!domain.id) {
-				console.error(ERRORS.FAILED_TO_LOAD_DOMAIN_ID);
-				return;
+				throw Error(ERRORS.FAILED_TO_LOAD_DOMAIN_ID);
 			}
 
 			try {

--- a/src/lib/hooks/useBidProvider.tsx
+++ b/src/lib/hooks/useBidProvider.tsx
@@ -12,7 +12,7 @@ import { useZnsSdk } from 'lib/hooks/sdk';
 import { Bid as zAuctionBid } from '@zero-tech/zauction-sdk/lib/api/types';
 import { PlaceBidStatus } from '@zero-tech/zauction-sdk';
 import { Web3Provider } from '@ethersproject/providers';
-import { ERRORS, MESSAGES } from 'constants/errors';
+import { ERRORS } from 'constants/errors';
 
 /////////////////////
 // Mock data stuff //
@@ -211,6 +211,11 @@ export const useBidProvider = (): UseBidProviderReturn => {
 				return;
 			}
 
+			if (!domain.id) {
+				console.error(ERRORS.FAILED_TO_LOAD_DOMAIN_ID);
+				return;
+			}
+
 			try {
 				await sdk.zauction.placeBid(
 					{
@@ -221,9 +226,10 @@ export const useBidProvider = (): UseBidProviderReturn => {
 					(status) => onPlaceBidStatusChange(status, onStep),
 				);
 				onStep('Generating bid...');
-			} catch (e) {
+			} catch (e: any) {
 				console.warn(e);
-				throw new Error(MESSAGES.MESSAGE_DENIED);
+				console.log(e);
+				throw new Error(e);
 			}
 		},
 		[sdk, library],

--- a/src/lib/hooks/useTransfer.tsx
+++ b/src/lib/hooks/useTransfer.tsx
@@ -66,8 +66,7 @@ export const useTransfer = (): UseTransferReturn => {
 					);
 				} catch (e: any) {
 					console.error(e);
-					const errorText = getDisplayErrorMessage(e.message);
-					throw new Error(errorText);
+					throw new Error(e.message);
 				}
 
 				// start transferring

--- a/src/lib/hooks/useTransfer.tsx
+++ b/src/lib/hooks/useTransfer.tsx
@@ -9,7 +9,6 @@ import { Web3Provider } from '@ethersproject/providers/lib/web3-provider';
 import { TransferSubmitParams } from 'lib/types';
 import useNotification from 'lib/hooks/useNotification';
 import { useZnsSdk } from 'lib/hooks/sdk';
-import { getDisplayErrorMessage } from 'lib/utils/error';
 
 //- Hooks
 import { useTransferRedux } from 'store/transfer/hooks';

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,12 +1,12 @@
 //- Constants Imports
 import { MESSAGES, ERRORS } from 'constants/errors';
 
-export const getErrorMessage = (err: any) => {
-	if (err.message.includes(MESSAGES.TRANSACTION_DENIED)) {
+export const getDisplayErrorMessage = (message: string) => {
+	if (message.includes(MESSAGES.TRANSACTION_DENIED)) {
 		return ERRORS.REJECTED_WALLET;
-	} else if (err.message.includes(MESSAGES.MESSAGE_DENIED)) {
+	} else if (message.includes(MESSAGES.MESSAGE_DENIED)) {
 		return ERRORS.REJECTED_WALLET;
-	} else if (err.message.includes(MESSAGES.DATA_CONSUMED)) {
+	} else if (message.includes(MESSAGES.DATA_CONSUMED)) {
 		return ERRORS.DATA_CONSUMED;
 	} else {
 		return ERRORS.PROBLEM_OCCURRED;

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,0 +1,12 @@
+//- Constants Imports
+import { MESSAGES, ERRORS } from 'constants/errors';
+
+export const getError = (err: any) => {
+	if (err.message.includes(MESSAGES.TRANSACTION_DENIED)) {
+		throw new Error(ERRORS.REJECTED_WALLET);
+	} else if (err.message.includes(MESSAGES.DATA_CONSUMED)) {
+		throw new Error(ERRORS.DATA_CONSUMED);
+	} else {
+		throw new Error(ERRORS.PROBLEM_OCCURRED);
+	}
+};

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,12 +1,12 @@
 //- Constants Imports
 import { MESSAGES, ERRORS } from 'constants/errors';
 
-export const getError = (err: any) => {
+export const getErrorMessage = (err: any) => {
 	if (err.message.includes(MESSAGES.TRANSACTION_DENIED)) {
-		throw new Error(ERRORS.REJECTED_WALLET);
+		return ERRORS.REJECTED_WALLET;
 	} else if (err.message.includes(MESSAGES.DATA_CONSUMED)) {
-		throw new Error(ERRORS.DATA_CONSUMED);
+		return ERRORS.DATA_CONSUMED;
 	} else {
-		throw new Error(ERRORS.PROBLEM_OCCURRED);
+		return ERRORS.PROBLEM_OCCURRED;
 	}
 };

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -4,6 +4,8 @@ import { MESSAGES, ERRORS } from 'constants/errors';
 export const getErrorMessage = (err: any) => {
 	if (err.message.includes(MESSAGES.TRANSACTION_DENIED)) {
 		return ERRORS.REJECTED_WALLET;
+	} else if (err.message.includes(MESSAGES.MESSAGE_DENIED)) {
+		return ERRORS.REJECTED_WALLET;
 	} else if (err.message.includes(MESSAGES.DATA_CONSUMED)) {
 		return ERRORS.DATA_CONSUMED;
 	} else {

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -6,6 +6,8 @@ export const getDisplayErrorMessage = (message: string) => {
 		return ERRORS.REJECTED_WALLET;
 	} else if (message.includes(MESSAGES.MESSAGE_DENIED)) {
 		return ERRORS.REJECTED_WALLET;
+	} else if (message.includes(MESSAGES.FAILED_TO_SIGN_BID)) {
+		return ERRORS.REJECTED_WALLET;
 	} else if (message.includes(MESSAGES.DATA_CONSUMED)) {
 		return ERRORS.DATA_CONSUMED;
 	} else {


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Team-Dash-78b824c0cd0e46c59c19dfe103ae929a?p=3a00de36dfad480e957d4afd630ec2d5)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
    - Bugfix


## 3. What is the old behaviour?
Accept bid error not specific enough. Text would always read 'Reject by wallet' for any error.
SetBuyNow errors not specific enough
BuyNow errors not specific enough
CancelBid errors not specific enough
MakeABid errors not specific enough
TransferOwnership errors not specific enough

## 4. What is the new behaviour?
Accept bid error handling improved. Generic error message added and some logic to determine generic or rejected message.
SetBuyNow specific errors
BuyNow  specific errors
CancelBid specific errorsh
MakeABid  specific errors
TransferOwnership specific errors
Error handling across wallet types tested (metamask & coinabase wallet)
Updated tests to reflect changes where required
