### PR TITLE
feat: improve title switching - add documentTitle util and tests

### DIFF
--- a/src/lib/providers/CurrentDomainProvider.tsx
+++ b/src/lib/providers/CurrentDomainProvider.tsx
@@ -3,19 +3,21 @@ import React, { useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 
 // Web3 Imports
+import { useWeb3React } from '@web3-react/core';
+import { Web3Provider } from '@ethersproject/providers';
+import { ConvertedTokenInfo } from '@zero-tech/zns-sdk';
+
+//- Library Imports
+import { useDocumentTitle } from 'lib/utils/documentTitle';
+import { defaultNetworkId } from 'lib/network';
+import { appFromPathname, getDomainId, zNAFromPathname } from 'lib/utils';
 import { useZnsDomain } from 'lib/hooks/useZnsDomain';
 import { usePropsState } from 'lib/hooks/usePropsState';
 import { DisplayParentDomain, Maybe, Metadata } from 'lib/types';
-import { useWeb3React } from '@web3-react/core';
-import { Web3Provider } from '@ethersproject/providers';
-import { defaultNetworkId } from 'lib/network';
-import { appFromPathname, getDomainId, zNAFromPathname } from 'lib/utils';
-import { ConvertedTokenInfo } from '@zero-tech/zns-sdk';
 
 // Constants Imports
 import { IS_DEFAULT_NETWORK, ROOT_DOMAIN } from '../../constants/domains';
 import { ROUTES } from 'constants/routes';
-
 export const CurrentDomainContext = React.createContext({
 	domain: undefined as Maybe<DisplayParentDomain>,
 	domainId: '',
@@ -28,17 +30,14 @@ export const CurrentDomainContext = React.createContext({
 	paymentToken: undefined as Maybe<string>,
 	paymentTokenInfo: {} as ConvertedTokenInfo,
 });
-
 const CurrentDomainProvider: React.FC = ({ children }) => {
 	//////////////////////////
 	// Hooks & State & Data //
 	//////////////////////////
-
 	const { chainId } = useWeb3React<Web3Provider>(); // get provider for connected wallet
 
 	// Get current domain from react-router-dom
 	const { pathname } = useLocation();
-
 	const domain = zNAFromPathname(pathname);
 
 	const zna =
@@ -46,10 +45,12 @@ const CurrentDomainProvider: React.FC = ({ children }) => {
 		(domain.length ? (IS_DEFAULT_NETWORK ? domain : '.' + domain) : '');
 
 	const domainId = getDomainId(zna);
+
 	const znsDomain = useZnsDomain(domainId, chainId || defaultNetworkId);
 	const [domainMetadata, setDomainMetadata] = usePropsState(
 		znsDomain.domainMetadata,
 	);
+
 	const appPathname = appFromPathname(pathname);
 	const app =
 		appPathname === ROUTES.STAKING
@@ -57,15 +58,7 @@ const CurrentDomainProvider: React.FC = ({ children }) => {
 			: appPathname;
 
 	// Change document title based on current network
-	if (
-		zna.length > 0 &&
-		zna !== process.env.REACT_APP_NETWORK &&
-		domainMetadata?.title
-	) {
-		document.title = process.env.REACT_APP_TITLE + ' | ' + domainMetadata.title;
-	} else {
-		document.title = process.env.REACT_APP_TITLE + ' | NFTs';
-	}
+	useDocumentTitle(zna, app, domainMetadata?.title);
 
 	const contextValue = {
 		domain: znsDomain.domain,
@@ -82,16 +75,13 @@ const CurrentDomainProvider: React.FC = ({ children }) => {
 			id: znsDomain.paymentToken || '',
 		},
 	};
-
 	return (
 		<CurrentDomainContext.Provider value={contextValue}>
 			{children}
 		</CurrentDomainContext.Provider>
 	);
 };
-
 export default CurrentDomainProvider;
-
 export function useCurrentDomain() {
 	return useContext(CurrentDomainContext);
 }

--- a/src/lib/utils/documentTitle.test.ts
+++ b/src/lib/utils/documentTitle.test.ts
@@ -1,0 +1,202 @@
+//- Utils Import
+import { ROUTES } from 'constants/routes';
+
+//- Constants Imports
+import { useDocumentTitle } from './documentTitle';
+
+//////////////////////////
+// f:: getDocumentTitle //
+//////////////////////////
+
+describe('getDocumentTitle', () => {
+	describe('Default Network (no network set)', () => {
+		const env = process.env;
+
+		beforeEach(() => {
+			jest.resetModules();
+			process.env = { ...env, REACT_APP_NETWORK: '', REACT_APP_TITLE: 'Zero' };
+		});
+
+		afterEach(() => {
+			process.env = env;
+		});
+
+		it('mock REACT_APP_NETWORK success', () => {
+			expect(process.env.REACT_APP_NETWORK).toBe('');
+			expect(process.env.REACT_APP_NETWORK).not.toBe('wilder');
+		});
+
+		describe('when Marketplace dApp', () => {
+			it('should display dApp root title when root domain', () => {
+				const zna = '';
+				const app = ROUTES.MARKET;
+				const domainMetadataTitle = undefined;
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe('Zero | NFTs');
+			});
+
+			it('should display subdomain metatdata title when subdomain(x1) and domainMetadataTitle', () => {
+				const zna = 'wilder';
+				const app = ROUTES.MARKET;
+				const domainMetadataTitle = 'Wilder World';
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe(`Zero | ${domainMetadataTitle}`);
+			});
+
+			it('should display subdomain metatdata title when subdomain(x2) and domainMetadataTitle', () => {
+				const zna = 'wilder.boat';
+				const app = ROUTES.MARKET;
+				const domainMetadataTitle = 'On the water';
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe(`Zero | ${domainMetadataTitle}`);
+			});
+		});
+
+		describe('when DAO dApp', () => {
+			it('should display dApp root title when root domain', () => {
+				const zna = '';
+				const app = ROUTES.ZDAO;
+				const domainMetadataTitle = undefined;
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe('Zero | DAOs');
+			});
+
+			it('should display subdomain metatdata title when dao subdomain and domainMetadataTitle', () => {
+				const zna = 'zero.dao';
+				const app = ROUTES.ZDAO;
+				const domainMetadataTitle = 'Test DAO One';
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe(`Zero | ${domainMetadataTitle}`);
+			});
+		});
+
+		describe('when Staking dApp', () => {
+			it('should display dApp root title when root domain', () => {
+				const zna = '';
+				const app = ROUTES.STAKING;
+				const domainMetadataTitle = undefined;
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe('Zero | Staking');
+			});
+		});
+
+		describe('when Profile path', () => {
+			it('should display Profile', () => {
+				const zna = '';
+				const app = ROUTES.PROFILE;
+				const domainMetadataTitle = undefined;
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe('Zero | Profile');
+			});
+		});
+	});
+
+	describe('Network Variable (network set)', () => {
+		const env = process.env;
+
+		beforeEach(() => {
+			jest.resetModules();
+			process.env = {
+				...env,
+				REACT_APP_NETWORK: 'wilder',
+				REACT_APP_TITLE: 'Wilder World',
+			};
+		});
+
+		afterEach(() => {
+			process.env = env;
+		});
+
+		describe('when Marketplace dApp', () => {
+			it('should display dApp root title when root domain', () => {
+				const zna = 'wilder';
+				const app = ROUTES.MARKET;
+				const domainMetadataTitle = undefined;
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe('Wilder World | NFTs');
+			});
+
+			it('should display subdomain metatdata title when subdomain(x1) and domainMetadataTitle', () => {
+				const zna = 'wilder.boat';
+				const app = ROUTES.MARKET;
+				const domainMetadataTitle = 'Test Subdomain';
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe(`Wilder World | ${domainMetadataTitle}`);
+			});
+
+			it('should display subdomain metatdata title when subdomain(x3) and domainMetadataTitle', () => {
+				const zna = 'wilder.boat.notreal';
+				const app = ROUTES.MARKET;
+				const domainMetadataTitle = 'On the water';
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe(`Wilder World | ${domainMetadataTitle}`);
+			});
+		});
+
+		describe('when DAO dApp', () => {
+			it('should display dApp root title when root domain', () => {
+				const zna = 'wilder';
+				const app = ROUTES.ZDAO;
+				const domainMetadataTitle = undefined;
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe('Wilder World | DAOs');
+			});
+
+			it('should display subdomain metatdata title when dao subdomain and domainMetadataTitle', () => {
+				const zna = 'wilder.test';
+				const app = ROUTES.ZDAO;
+				const domainMetadataTitle = 'Test DAO One';
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe(`Wilder World | ${domainMetadataTitle}`);
+			});
+		});
+
+		describe('when Staking dApp', () => {
+			it('should display dApp root title when root domain', () => {
+				const zna = 'wilder';
+				const app = ROUTES.STAKING;
+				const domainMetadataTitle = undefined;
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe('Wilder World | Staking');
+			});
+		});
+
+		describe('when Profile path', () => {
+			it('should display Profile', () => {
+				const zna = '';
+				const app = ROUTES.PROFILE;
+				const domainMetadataTitle = undefined;
+
+				useDocumentTitle(zna, app, domainMetadataTitle);
+
+				expect(document.title).toBe('Wilder World | Profile');
+			});
+		});
+	});
+});

--- a/src/lib/utils/documentTitle.ts
+++ b/src/lib/utils/documentTitle.ts
@@ -1,0 +1,35 @@
+//- Constants Imports
+import { ROUTES } from 'constants/routes';
+
+export const useDocumentTitle = (
+	zna: string,
+	app: string,
+	domainMetadataTitle?: string,
+) => {
+	const isRootZNA = zna.split('.').length === 1;
+	const isMarketTitle = isRootZNA && app === ROUTES.MARKET;
+	const isZDAOTitle = isRootZNA && app === ROUTES.ZDAO;
+	const isStakingTitle = app.includes(ROUTES.STAKING);
+	const isProfileTitle = app.includes(ROUTES.PROFILE);
+
+	// set title
+	if (
+		zna.length > 0 &&
+		zna !== process.env.REACT_APP_NETWORK &&
+		domainMetadataTitle
+	) {
+		document.title = process.env.REACT_APP_TITLE + ' | ' + domainMetadataTitle;
+	} else {
+		if (isMarketTitle) {
+			document.title = process.env.REACT_APP_TITLE + ' | NFTs';
+		} else if (isZDAOTitle) {
+			document.title = process.env.REACT_APP_TITLE + ' | DAOs';
+		} else if (isStakingTitle) {
+			document.title = process.env.REACT_APP_TITLE + ' | Staking';
+		} else if (isProfileTitle) {
+			document.title = process.env.REACT_APP_TITLE + ' | Profile';
+		} else {
+			document.title = String(process.env.REACT_APP_TITLE);
+		}
+	}
+};


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/0-17-0-zAuction-2-1-network-switcher-a2c4a3409df541a197682d740babc572?p=c4f1d43fcb1d456f86ff090be1eabdd5)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] feature / improvements


## 3. What is the old behaviour?
Head data title switching was limited to either NFTs or DAOs.

## 4. What is the new behaviour?
Head data title switching will now display the relevant page / metadata title


LOOM
https://www.loom.com/share/b8556fcdc2b14ab7be1b7d529601e3f4