### PR TITLE
fix: Bid Table (Your Bids) - handle close modal events when successfully placing a bid

### DIFF
--- a/src/containers/flows/MakeABid/MakeABid.tsx
+++ b/src/containers/flows/MakeABid/MakeABid.tsx
@@ -196,6 +196,8 @@ const MakeABid = ({
 			);
 			setIsBidPlaced(true);
 			setStepContent(StepContent.Success);
+			// refetch bid data once bid successful
+			onBid();
 		} catch (e) {
 			if (!isMounted.current) {
 				return;
@@ -219,14 +221,6 @@ const MakeABid = ({
 	const onStepNavigation = (i: number) => {
 		setCurrentStep(i);
 		setStepContent(i);
-	};
-
-	/*
-	 * Handles close modal events on successful bid placed
-	 */
-	const handleCloseModal = () => {
-		onBid();
-		onClose();
 	};
 
 	/**
@@ -346,7 +340,7 @@ const MakeABid = ({
 				tokenBalance={tokenBalance}
 				highestBid={bidData?.highestBid?.amount}
 				bid={bid}
-				onClose={handleCloseModal}
+				onClose={onClose}
 				paymentTokenInfo={paymentTokenInfo}
 			/>
 		),

--- a/src/containers/flows/MakeABid/MakeABid.tsx
+++ b/src/containers/flows/MakeABid/MakeABid.tsx
@@ -221,6 +221,14 @@ const MakeABid = ({
 		setStepContent(i);
 	};
 
+	/*
+	 * Handles close modal events on successful bid placed
+	 */
+	const handleCloseModal = () => {
+		onBid();
+		onClose();
+	};
+
 	/**
 	 * URL to the image for the NFT being bidded on
 	 */
@@ -338,7 +346,7 @@ const MakeABid = ({
 				tokenBalance={tokenBalance}
 				highestBid={bidData?.highestBid?.amount}
 				bid={bid}
-				onClose={onBid}
+				onClose={handleCloseModal}
 				paymentTokenInfo={paymentTokenInfo}
 			/>
 		),


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/0-17-0-zAuction-2-1-network-switcher-a2c4a3409df541a197682d740babc572?p=3820b5bbfde946d0ba0a294000bff4f1)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- [x] Bug


## 3. What is the old behaviour?
Success step of place a bid flow does not handle the modal closing when selecting 'Finish' button.


## 4. What is the new behaviour?
Clicking 'Finish' button will now close the modal and refetch bid data.

Fix:


https://user-images.githubusercontent.com/39112648/180021369-c404afac-21c2-4496-b28d-ed722180a8e6.mov



