### PR TITLE
feat: users not holding voting token should be blocked from create proposal page

### DIFF
--- a/src/containers/DAO/pages/Container.module.scss
+++ b/src/containers/DAO/pages/Container.module.scss
@@ -109,3 +109,7 @@
 		padding-right: 0;
 	}
 }
+
+.Hidden {
+	display: none !important;
+}

--- a/src/containers/DAO/pages/DAOPage/DAOPage.module.scss
+++ b/src/containers/DAO/pages/DAOPage/DAOPage.module.scss
@@ -72,3 +72,7 @@
 		margin-top: 16px;
 	}
 }
+
+.Hidden {
+	display: none;
+}

--- a/src/containers/DAO/pages/DAOPage/DAOPage.module.scss
+++ b/src/containers/DAO/pages/DAOPage/DAOPage.module.scss
@@ -72,7 +72,3 @@
 		margin-top: 16px;
 	}
 }
-
-.Hidden {
-	display: none;
-}

--- a/src/containers/DAO/pages/DAOPage/DAOPage.tsx
+++ b/src/containers/DAO/pages/DAOPage/DAOPage.tsx
@@ -26,6 +26,7 @@ import { useProposals } from 'lib/dao/providers/ProposalsProvider';
 
 // Lib
 import { toFiat } from 'lib/currency';
+import useBalance from 'lib/hooks/useBalance';
 import { ROUTES } from 'constants/routes';
 import millify from 'millify';
 
@@ -59,6 +60,7 @@ const DAOPage: React.FC = () => {
 		useTransactions(dao);
 	const { assets, totalUsd, isLoading: isLoadingAssets } = useAssets(dao);
 	const { fetch: fetchProposals } = useProposals();
+	const { balance } = useBalance(dao?.votingToken.token);
 
 	const daoData = dao;
 
@@ -99,7 +101,14 @@ const DAOPage: React.FC = () => {
 				<Loading />
 			) : dao ? (
 				<>
-					<div id="dao-page-nav-tabs">
+					<div
+						className={cx({
+							// @TODO: improve the following logic
+							Hidden:
+								pathname.split(zna)[1].startsWith('/proposals/create') ||
+								pathname.split(zna)[1].startsWith('/proposals/0x'),
+						})}
+					>
 						<Link className={styles.Back} to={ROUTES.ZDAO}>
 							<ArrowLeft /> All DAOs
 						</Link>
@@ -156,7 +165,7 @@ const DAOPage: React.FC = () => {
 							</div>
 
 							{/* New Proposal Button */}
-							{pathname === to(ROUTES.ZDAO_PROPOSALS) && (
+							{pathname === to(ROUTES.ZDAO_PROPOSALS) && balance?.gt(0) && (
 								<FutureButton glow onClick={handleNewProposalButtonClick}>
 									New Proposal
 								</FutureButton>

--- a/src/containers/DAO/pages/DAOPage/Proposals/CreateProposal/CreateProposal.module.scss
+++ b/src/containers/DAO/pages/DAOPage/Proposals/CreateProposal/CreateProposal.module.scss
@@ -1,12 +1,11 @@
 @use 'styles/variables/dimensions';
 
 .Container {
-	margin: 24px 0 !important;
+	//margin: 24px 0 !important;
 
 	.NavLink {
 		display: flex;
 		align-items: center;
-		margin: 8px 0;
 		color: var(--color-text-primary);
 		font-size: 14px;
 		font-weight: bold;
@@ -25,7 +24,7 @@
 
 	.Content {
 		.Title {
-			margin-top: 24px;
+			margin-top: 36px;
 			font-size: 36px;
 			font-weight: 700;
 			line-height: 44px;
@@ -404,4 +403,11 @@
 			margin-top: 24px;
 		}
 	}
+
+}
+
+.TokenError {
+	font-weight: bold;
+	text-align: center;
+	margin-top: 40px;
 }

--- a/src/containers/DAO/pages/DAOPage/Proposals/CreateProposal/CreateProposal.tsx
+++ b/src/containers/DAO/pages/DAOPage/Proposals/CreateProposal/CreateProposal.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 // - Library
 import type { zDAO } from '@zero-tech/zdao-sdk';
+import { zNAFromPathname } from 'lib/utils';
+import { ROUTES } from 'constants/routes';
 
 // - Component
 import { ArrowLeft } from 'react-feather';
@@ -30,15 +32,19 @@ export const CreateProposal: React.FC<CreateProposalProps> = ({ dao }) => {
 		tokenDropdownOptions,
 		handleGoToAllProposals,
 		handleHideConnectWallet,
+		isHoldingVotingToken,
 	} = useCreateProposal(dao);
+
+	const { pathname } = useLocation();
+	const zna = zNAFromPathname(pathname);
 
 	return (
 		<>
 			<div className={styles.Container}>
 				<Link
 					className={styles.NavLink}
-					to={'#'}
-					onClick={handleGoToAllProposals}
+					to={showForm ? '#' : `${ROUTES.ZDAO}/${zna}${ROUTES.ZDAO_PROPOSALS}`}
+					onClick={showForm ? handleGoToAllProposals : undefined}
 				>
 					<ArrowLeft /> All Proposals
 				</Link>
@@ -68,6 +74,17 @@ export const CreateProposal: React.FC<CreateProposalProps> = ({ dao }) => {
 							tokenDropdownOptions={tokenDropdownOptions}
 						/>
 					)}
+
+					{!isLoading &&
+						!isHoldingVotingToken &&
+						dao &&
+						!notes.ConnectWallet.show && (
+							<p className={styles.TokenError}>
+								To create a proposal, you need to be holding the {dao?.title}{' '}
+								voting token
+								{dao.votingToken.symbol && ` (${dao.votingToken.symbol})`}.
+							</p>
+						)}
 				</div>
 			</div>
 		</>

--- a/src/containers/DAO/pages/DAOPage/Proposals/ProposalDetail/ProposalDetail.tsx
+++ b/src/containers/DAO/pages/DAOPage/Proposals/ProposalDetail/ProposalDetail.tsx
@@ -10,8 +10,6 @@ import {
 } from '../Proposals.helpers';
 
 // - Hooks
-import { useDidMount } from 'lib/hooks/useDidMount';
-import { useWillUnmount } from 'lib/hooks/useWillUnmount';
 import { useUpdateEffect } from 'lib/hooks/useUpdateEffect';
 import { usePrevious } from 'lib/hooks/usePrevious';
 import { useProposals } from 'lib/dao/providers/ProposalsProvider';
@@ -21,12 +19,12 @@ import useProposal from '../../hooks/useProposal';
 import { ArrowLeft } from 'react-feather';
 import { LoadingIndicator, MarkDownViewer } from 'components';
 import { VoteBar } from './VoteBar';
+import Vote from './Vote/Vote';
 import { ProposalAttributes } from './ProposalAttributes';
 import { VoteHistories } from './VoteHistories';
 
 // - Styles
 import styles from './ProposalDetail.module.scss';
-import Vote from './Vote/Vote';
 
 type ProposalDetailProps = {
 	dao?: zDAO;
@@ -34,20 +32,6 @@ type ProposalDetailProps = {
 
 export const ProposalDetail: React.FC<ProposalDetailProps> = ({ dao }) => {
 	const [triggerRefresh, setTriggerRefresh] = useState<boolean>(false);
-
-	useDidMount(() => {
-		const nav = document.getElementById('dao-page-nav-tabs');
-		if (nav) {
-			nav.style.display = 'none';
-		}
-	});
-
-	useWillUnmount(() => {
-		const nav = document.getElementById('dao-page-nav-tabs');
-		if (nav) {
-			nav.style.display = 'block';
-		}
-	});
 
 	const history = useHistory();
 	const { proposalId } = useParams<{ proposalId: ProposalId }>();

--- a/src/lib/dao/hooks/useDao.ts
+++ b/src/lib/dao/hooks/useDao.ts
@@ -15,12 +15,12 @@ const useDao = (zna: string): UseDaoReturn => {
 
 	useEffect(() => {
 		let isMounted = true;
+		setDao(undefined);
+		setIsLoading(true);
 		if (!sdk || !zna || zna.length === 0) {
 			setIsLoading(false);
 			return;
 		}
-		setDao(undefined);
-		setIsLoading(true);
 		try {
 			sdk.getZDAOByZNA(zna).then((d) => {
 				if (isMounted) {

--- a/src/lib/hooks/useBalance.ts
+++ b/src/lib/hooks/useBalance.ts
@@ -34,7 +34,6 @@ const useBalance = (tokenId?: string) => {
 					account!,
 					tokenId!,
 				);
-				console.log(`balance for ${account} is ${balance.toString()}`);
 				if (isMounted) {
 					setBalance(balance);
 				}

--- a/src/lib/hooks/useBalance.ts
+++ b/src/lib/hooks/useBalance.ts
@@ -1,0 +1,64 @@
+import { useZnsSdk } from 'lib/hooks/sdk';
+import { useEffect, useState } from 'react';
+import { BigNumber } from 'ethers';
+import { useWeb3React } from '@web3-react/core';
+
+/**
+ * Gets a user's balance as part of the parent
+ * component's lifecycle.
+ * tokenId is optional as often the token ID loads asynchronously.
+ * This should be improved later down the line.
+ * @param tokenId token to get balance for
+ */
+const useBalance = (tokenId?: string) => {
+	const { instance: znsSdk } = useZnsSdk();
+	const { account } = useWeb3React();
+
+	const [isLoading, setIsLoading] = useState<boolean>(true);
+	const [balance, setBalance] = useState<BigNumber | undefined>();
+
+	useEffect(() => {
+		let isMounted = true;
+
+		setIsLoading(true);
+		setBalance(undefined);
+
+		if (!(account ?? '').length || !(tokenId ?? '').length) {
+			setIsLoading(false);
+			return;
+		}
+
+		(async () => {
+			try {
+				const balance = await znsSdk.zauction.getUserBalanceForPaymentToken(
+					account!,
+					tokenId!,
+				);
+				console.log(`balance for ${account} is ${balance.toString()}`);
+				if (isMounted) {
+					setBalance(balance);
+				}
+			} catch (e) {
+				console.error(
+					`Failed to get balance of ${account} for token ${tokenId}`,
+				);
+			} finally {
+				if (isMounted) {
+					setIsLoading(false);
+				}
+			}
+		})();
+
+		return () => {
+			isMounted = false;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [tokenId, account]);
+
+	return {
+		isLoading,
+		balance,
+	};
+};
+
+export default useBalance;


### PR DESCRIPTION

<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/Prevent-users-not-holding-voting-token-from-accessing-Create-Proposal-1cdea0363c9e4ebe9b97f37196535193)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Feature


## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

Users who were not holding the DAO's voting token were able to access the Create Proposal flow.

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

The UI prevents users who are not holding the DAO's voting token from accessing the Create Proposal flow. It does this by:
1. Check voting token balance on Proposals page before showing "New Proposal" button
2. Check voting token balance on Create Proposal page - show error message if no balance

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
