### PR TITLE
fix: wilder logo resetting on app change

### DIFF
--- a/src/components/SideBar/SideBar.utils.ts
+++ b/src/components/SideBar/SideBar.utils.ts
@@ -3,18 +3,14 @@ import { DOMAIN_LOGOS, ROOT_DOMAIN } from 'constants/domains';
 import { ROUTES } from 'constants/routes';
 
 export const getNetworkLogo = (zna: string, app: string) => {
-	if (ROOT_DOMAIN !== 'wilder') {
-		if (zna.startsWith('wilder')) {
-			return DOMAIN_LOGOS.WILDER_WORLD;
-		} else {
-			return DOMAIN_LOGOS.ZERO;
-		}
+	if (ROOT_DOMAIN === 'wilder') {
+		return DOMAIN_LOGOS.WILDER_WORLD;
+	}
+
+	if (zna.startsWith('wilder')) {
+		return DOMAIN_LOGOS.WILDER_WORLD;
 	} else {
-		if (app === ROUTES.MARKET) {
-			return DOMAIN_LOGOS.WILDER_WORLD;
-		} else {
-			return DOMAIN_LOGOS.ZERO;
-		}
+		return DOMAIN_LOGOS.ZERO;
 	}
 };
 


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/Wilder-logo-resetting-on-app-change-6f3ad6f5ac7549df90301a2215af11c2)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
<!-- 
  Please try to limit your pull request to one type, submit multiple pull requests if needed. 
  One of:
    - Bugfix
    - Feature
    - Code style update (formatting, renaming)
    - Refactoring (no functional changes, no api changes)
    - Build related changes
    - Documentation content changes
    - Other (please describe):
--> 

Feature


## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->

Logo in the sidebar was changing when switching between apps on the WWMM. In the WWMM, the logo should always be the WW logo.

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

Logo doesn't change on WWMM.

## 5. Other information
<!-- Optional: any other information that is important to this PR such as a Loom or screenshots describing behaviour outlined in Step 4. -->
