### PR TITLE
feat: refactor media input into seperate component

### DIFF
--- a/src/components/Inputs/MediaInput/MediaInput.module.scss
+++ b/src/components/Inputs/MediaInput/MediaInput.module.scss
@@ -1,0 +1,56 @@
+@use 'styles/variables/animations';
+@use 'styles/variables/colors';
+
+$width: 640px;
+$gutter: 16px;
+
+.Preview {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	height: 224px;
+	width: 224px;
+	min-width: 224px;
+
+	background-size: cover;
+	background-position: center;
+	background-repeat: no-repeat;
+
+	border: 1px solid #88d7ff;
+	overflow: hidden;
+
+	cursor: pointer;
+	transition: transform #{animations.$time-medium} ease-in-out,
+		border-color #{animations.$time-medium} ease-in-out;
+
+	@media only screen and (max-width: #{$width + $gutter + $gutter}) {
+		width: auto;
+		max-width: 224px;
+	}
+
+	& > img {
+		height: 100%;
+	}
+
+	& > img,
+	& > video {
+		max-height: 100%;
+		max-width: 100%;
+		object-fit: contain;
+		transition: transform #{animations.$time-medium} ease-in-out;
+	}
+
+	.Uploaded {
+		background: rgba(colors.$black, 0.3);
+		border: none;
+		overflow: visible;
+		border-radius: 0;
+		margin: 0 auto;
+
+		&:hover > img,
+		&:hover > video {
+			transform: scale(1.05);
+		}
+	}
+}

--- a/src/components/Inputs/MediaInput/MediaInput.tsx
+++ b/src/components/Inputs/MediaInput/MediaInput.tsx
@@ -1,0 +1,76 @@
+import { useRef } from 'react';
+
+//- Style Imports
+import styles from './MediaInput.module.scss';
+
+type MediaInputProps = {
+	previewImage: string;
+	mediaType: string | undefined;
+	hasError: boolean;
+	onChange: (mediaType: string, previewImage: string, image: Buffer) => void;
+};
+
+const MediaInput: React.FC<MediaInputProps> = ({
+	previewImage,
+	mediaType,
+	hasError,
+	onChange,
+}) => {
+	const inputFile = useRef<HTMLInputElement>(null);
+
+	const openUploadDialog = () =>
+		inputFile.current ? inputFile.current.click() : null;
+
+	const onImageChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
+		if (event.target.files && event.target.files[0]) {
+			const type = event.target.files[0].type;
+			if (!type.includes('image') && !type.includes('video')) return;
+
+			// Raw data for image preview
+			const url = URL.createObjectURL(event.target.files[0]);
+
+			// Uint8Array data for sending to IPFS
+			const bufferReader = new FileReader();
+			bufferReader.readAsArrayBuffer(event.target.files[0]);
+			bufferReader.onloadend = () =>
+				onChange(
+					type.includes('image') ? 'image' : 'video',
+					url,
+					Buffer.from(bufferReader.result as ArrayBuffer),
+				);
+		}
+	};
+
+	return (
+		<>
+			<div
+				onClick={openUploadDialog}
+				className={`${styles.Preview} border-rounded ${
+					previewImage && styles.Uploaded
+				}`}
+				style={{
+					borderColor: hasError ? '#d379ff' : '',
+				}}
+			>
+				{!previewImage && <span className="glow-text-white">Choose Media</span>}
+				{previewImage && mediaType === 'image' && (
+					<img alt="NFT Preview" src={previewImage as string} />
+				)}
+				{previewImage && mediaType === 'video' && (
+					<video autoPlay controls loop src={previewImage as string} />
+				)}
+			</div>
+			<input
+				style={{ display: 'none' }}
+				accept="image/*,video/*,video/quicktime"
+				multiple={false}
+				name={'media'}
+				type="file"
+				onChange={onImageChanged}
+				ref={inputFile}
+			/>
+		</>
+	);
+};
+
+export default MediaInput;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -49,6 +49,7 @@ export * from './EtherscanLink';
 export { default as EtherInput } from './Inputs/EtherInput/EtherInput';
 export { default as TextInput } from './Inputs/TextInput/TextInput';
 export { default as TextInputWithTopPlaceHolder } from './Inputs/TextInput/TextInputWithTopPlaceHolder';
+export { default as MediaInput } from './Inputs/MediaInput/MediaInput';
 
 // - Markdown
 export { default as MarkDownEditor } from './MarkDown/MarkDownEditor';

--- a/src/containers/flows/MintNewNFT/MintNewNFT.module.scss
+++ b/src/containers/flows/MintNewNFT/MintNewNFT.module.scss
@@ -112,8 +112,6 @@ $gutter: 16px;
 	background-size: cover;
 	background-position: center;
 	background-repeat: no-repeat;
-
-	border: 1px solid #88d7ff;
 	overflow: hidden;
 
 	cursor: pointer;
@@ -124,35 +122,31 @@ $gutter: 16px;
 		width: auto;
 		max-width: 224px;
 	}
-}
 
-/* .NFT:not(.Uploaded):hover {
-	transform: scale(1.03);
-} */
+	& > img {
+		height: 100%;
+	}
 
-.NFT.Uploaded {
-	background: rgba(colors.$black, 0.3);
-	border: none;
-	overflow: visible;
-	border-radius: 0;
-	margin: 0 auto;
-}
+	& > img,
+	& > video {
+		max-height: 100%;
+		max-width: 100%;
+		object-fit: contain;
+		transition: transform #{animations.$time-medium} ease-in-out;
+	}
 
-.Uploaded:hover > img,
-.Uploaded:hover > video {
-	transform: scale(1.05);
-}
+	.Uploaded {
+		background: rgba(colors.$black, 0.3);
+		border: none;
+		overflow: visible;
+		border-radius: 0;
+		margin: 0 auto;
 
-.NFT > img {
-	height: 100%;
-}
-
-.NFT > img,
-.NFT > video {
-	max-height: 100%;
-	max-width: 100%;
-	object-fit: contain;
-	transition: transform #{animations.$time-medium} ease-in-out;
+		&:hover > img,
+		&:hover > video {
+			transform: scale(1.05);
+		}
+	}
 }
 
 .Inputs {

--- a/src/containers/flows/MintNewNFT/sections/TokenInformation.tsx
+++ b/src/containers/flows/MintNewNFT/sections/TokenInformation.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 //- React Imports
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 
 //- Local Imports
 import { TokenInformationType } from '../types';
@@ -9,7 +9,7 @@ import { TokenInformationType } from '../types';
 import styles from '../MintNewNFT.module.scss';
 
 //- Component Imports
-import { TextInput, FutureButton } from 'components';
+import { TextInput, FutureButton, MediaInput } from 'components';
 
 type TokenInformationProps = {
 	existingSubdomains: string[];
@@ -69,27 +69,14 @@ const TokenInformation: React.FC<TokenInformationProps> = ({
 		return errs[errs.length - 1]?.text || '';
 	};
 
-	//- Image Upload Handling
-	// TODO: Split image uploads into a new component
-	const inputFile = useRef<HTMLInputElement>(null);
-	const openUploadDialog = () =>
-		inputFile.current ? inputFile.current.click() : null;
-	const onImageChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
-		if (event.target.files && event.target.files[0]) {
-			const type = event.target.files[0].type;
-			// Raw data for image preview
-			const url = URL.createObjectURL(event.target.files[0]);
-			if (type.indexOf('image') > -1) setMediaType('image');
-			else if (type.indexOf('video') > -1) setMediaType('video');
-			else return;
-			setPreviewImage(url);
-
-			// Uint8Array data for sending to IPFS
-			const bufferReader = new FileReader();
-			bufferReader.readAsArrayBuffer(event.target.files[0]);
-			bufferReader.onloadend = () =>
-				setImage(Buffer.from(bufferReader.result as ArrayBuffer));
-		}
+	const handleMediaChange = (
+		mediaType: string,
+		previewImage: string,
+		image: Buffer,
+	): void => {
+		setMediaType(mediaType);
+		setPreviewImage(previewImage);
+		setImage(image);
 	};
 
 	const pressContinue = () => {
@@ -155,34 +142,12 @@ const TokenInformation: React.FC<TokenInformationProps> = ({
 		<div className={styles.Section}>
 			<form>
 				<div className={styles.FlexWrapper}>
-					<div
-						onClick={openUploadDialog}
-						className={`${styles.NFT} border-rounded ${
-							previewImage && styles.Uploaded
-						}`}
-						style={{
-							borderColor: hasError('image') ? '#d379ff' : '',
-						}}
-					>
-						{!previewImage && (
-							<span className="glow-text-white">Choose Media</span>
-						)}
-						{previewImage && mediaType === 'image' && (
-							<img alt="NFT Preview" src={previewImage as string} />
-						)}
-						{previewImage && mediaType === 'video' && (
-							<video autoPlay controls loop src={previewImage as string} />
-						)}
-					</div>
-					<input
-						style={{ display: 'none' }}
-						accept="image/*,video/*,video/quicktime"
-						multiple={false}
-						name={'media'}
-						type="file"
-						onChange={onImageChanged}
-						ref={inputFile}
-					></input>
+					<MediaInput
+						previewImage={previewImage}
+						mediaType={mediaType}
+						hasError={hasError('image')}
+						onChange={handleMediaChange}
+					/>
 					<div className={styles.Inputs}>
 						<TextInput
 							placeholder={'Title'}
@@ -200,12 +165,6 @@ const TokenInformation: React.FC<TokenInformationProps> = ({
 							alphanumeric
 							maxLength={25}
 						/>
-						{/* <ToggleButton
-							toggled={locked}
-							onClick={() => setLocked(!locked)}
-							style={{ marginTop: 'auto', alignSelf: 'center' }}
-							labels={['Unlocked', 'Locked']}
-						/> */}
 					</div>
 				</div>
 				<TextInput


### PR DESCRIPTION
[Refactor Media Input into separate Component](https://www.notion.so/rational-nomads/Refactor-Media-Input-into-separate-Component-0e619c95fc2e4ce8aeff8fedaaaa9f0e)

-----

## 1. Pull request checklist
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
```
- Feature
```

## 3. What is the old behaviour?
Media input elements and behaviour included as part of the TokenInformation component meaning it's not available for reuse elsewhere in the codebase.

## 4. What is the new behaviour?
Media Input refactored into individual component. This allows us to use in both the existing mint NFT flow and the coming Token Launcher project.