### PR TITLE
chore: bump zdao-sdk `0.11.2` -> `0.13.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"@web3-react/walletconnect-connector": "6.2.4",
 				"@web3-react/walletlink-connector": "^6.1.9",
 				"@zero-tech/zauction-sdk": "0.2.12",
-				"@zero-tech/zdao-sdk": "0.11.2",
+				"@zero-tech/zdao-sdk": "0.13.2",
 				"@zero-tech/zero-contracts": "^0.0.7",
 				"@zero-tech/zfi-sdk": "0.2.2",
 				"@zero-tech/zns-sdk": "0.9.3",
@@ -2626,7 +2626,8 @@
 		},
 		"node_modules/@ensdomains/eth-ens-namehash": {
 			"version": "2.0.15",
-			"license": "ISC"
+			"resolved": "https://registry.npmjs.org/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz",
+			"integrity": "sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw=="
 		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "0.4.3",
@@ -3364,20 +3365,6 @@
 		"node_modules/@gar/promisify": {
 			"version": "1.1.3",
 			"license": "MIT"
-		},
-		"node_modules/@gnosis.pm/safe-react-gateway-sdk": {
-			"version": "2.10.1",
-			"license": "MIT",
-			"dependencies": {
-				"cross-fetch": "^3.1.5"
-			}
-		},
-		"node_modules/@gnosis.pm/safe-react-gateway-sdk/node_modules/cross-fetch": {
-			"version": "3.1.5",
-			"license": "MIT",
-			"dependencies": {
-				"node-fetch": "2.6.7"
-			}
 		},
 		"node_modules/@graphql-codegen/cli": {
 			"version": "1.21.3",
@@ -5863,6 +5850,22 @@
 			"version": "0.0.39",
 			"license": "MIT"
 		},
+		"node_modules/@safe-global/safe-gateway-typescript-sdk": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.7.0.tgz",
+			"integrity": "sha512-3BvlUgp0oZ1Zkn7nG3wY1jvCEE4t530BjKcaa3r0qsf0whf/ez/0gmQwk7DTOGmVmvOfjj6HHikxnrUCCX+/3Q==",
+			"dependencies": {
+				"cross-fetch": "^3.1.5"
+			}
+		},
+		"node_modules/@safe-global/safe-gateway-typescript-sdk/node_modules/cross-fetch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+			"dependencies": {
+				"node-fetch": "2.6.7"
+			}
+		},
 		"node_modules/@samverschueren/stream-to-observable": {
 			"version": "0.3.1",
 			"license": "MIT",
@@ -5904,29 +5907,665 @@
 			}
 		},
 		"node_modules/@snapshot-labs/snapshot.js": {
-			"version": "0.3.56",
-			"license": "MIT",
+			"version": "0.4.58",
+			"resolved": "https://registry.npmjs.org/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.58.tgz",
+			"integrity": "sha512-dtfeiB0kEtpkQXKtc/MXrCj2cy3/CbbtNKMKudm/aLCTyK3DzYtQyvPLxQ1LwEvFcmf+1w3F6LAPENtmuj9obQ==",
 			"dependencies": {
 				"@ensdomains/eth-ens-namehash": "^2.0.15",
-				"@ethersproject/abi": "^5.0.4",
-				"@ethersproject/bytes": "^5.0.8",
-				"@ethersproject/contracts": "^5.0.3",
-				"@ethersproject/hash": "^5.0.9",
-				"@ethersproject/providers": "^5.3.1",
-				"@ethersproject/wallet": "^5.4.0",
-				"ajv": "^8.6.0",
-				"ajv-formats": "^2.1.0",
-				"cross-fetch": "^3.0.6",
-				"json-to-graphql-query": "^2.0.0",
+				"@ethersproject/abi": "^5.6.4",
+				"@ethersproject/address": "^5.6.1",
+				"@ethersproject/bytes": "^5.6.1",
+				"@ethersproject/contracts": "^5.6.2",
+				"@ethersproject/hash": "^5.6.1",
+				"@ethersproject/providers": "^5.6.8",
+				"@ethersproject/wallet": "^5.6.2",
+				"ajv": "^8.11.0",
+				"ajv-formats": "^2.1.1",
+				"cross-fetch": "^3.1.5",
+				"json-to-graphql-query": "^2.2.4",
 				"lodash.set": "^4.3.2"
 			},
 			"engines": {
 				"node": ">=14"
 			}
 		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/abi": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+			"integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/address": "^5.7.0",
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/constants": "^5.7.0",
+				"@ethersproject/hash": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/strings": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/abstract-provider": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+			"integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/networks": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/transactions": "^5.7.0",
+				"@ethersproject/web": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/abstract-signer": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+			"integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-provider": "^5.7.0",
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/address": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+			"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/base64": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+			"integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/basex": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+			"integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/bignumber": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+			"integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"bn.js": "^5.2.1"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/bytes": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+			"integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/logger": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/constants": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+			"integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/contracts": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+			"integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abi": "^5.7.0",
+				"@ethersproject/abstract-provider": "^5.7.0",
+				"@ethersproject/abstract-signer": "^5.7.0",
+				"@ethersproject/address": "^5.7.0",
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/constants": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/transactions": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/hash": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+			"integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-signer": "^5.7.0",
+				"@ethersproject/address": "^5.7.0",
+				"@ethersproject/base64": "^5.7.0",
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/strings": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/hdnode": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+			"integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-signer": "^5.7.0",
+				"@ethersproject/basex": "^5.7.0",
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/pbkdf2": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/sha2": "^5.7.0",
+				"@ethersproject/signing-key": "^5.7.0",
+				"@ethersproject/strings": "^5.7.0",
+				"@ethersproject/transactions": "^5.7.0",
+				"@ethersproject/wordlists": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/json-wallets": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+			"integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-signer": "^5.7.0",
+				"@ethersproject/address": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/hdnode": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/pbkdf2": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/random": "^5.7.0",
+				"@ethersproject/strings": "^5.7.0",
+				"@ethersproject/transactions": "^5.7.0",
+				"aes-js": "3.0.0",
+				"scrypt-js": "3.0.1"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/keccak256": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+			"integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"js-sha3": "0.8.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/logger": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+			"integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			]
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/networks": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+			"integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/logger": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/pbkdf2": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+			"integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/sha2": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/properties": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+			"integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/logger": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/providers": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+			"integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-provider": "^5.7.0",
+				"@ethersproject/abstract-signer": "^5.7.0",
+				"@ethersproject/address": "^5.7.0",
+				"@ethersproject/base64": "^5.7.0",
+				"@ethersproject/basex": "^5.7.0",
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/constants": "^5.7.0",
+				"@ethersproject/hash": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/networks": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/random": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0",
+				"@ethersproject/sha2": "^5.7.0",
+				"@ethersproject/strings": "^5.7.0",
+				"@ethersproject/transactions": "^5.7.0",
+				"@ethersproject/web": "^5.7.0",
+				"bech32": "1.1.4",
+				"ws": "7.4.6"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/random": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+			"integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/rlp": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+			"integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/sha2": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+			"integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"hash.js": "1.1.7"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/signing-key": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+			"integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"bn.js": "^5.2.1",
+				"elliptic": "6.5.4",
+				"hash.js": "1.1.7"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/strings": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+			"integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/constants": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/transactions": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+			"integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/address": "^5.7.0",
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/constants": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/rlp": "^5.7.0",
+				"@ethersproject/signing-key": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/wallet": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+			"integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-provider": "^5.7.0",
+				"@ethersproject/abstract-signer": "^5.7.0",
+				"@ethersproject/address": "^5.7.0",
+				"@ethersproject/bignumber": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/hash": "^5.7.0",
+				"@ethersproject/hdnode": "^5.7.0",
+				"@ethersproject/json-wallets": "^5.7.0",
+				"@ethersproject/keccak256": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/random": "^5.7.0",
+				"@ethersproject/signing-key": "^5.7.0",
+				"@ethersproject/transactions": "^5.7.0",
+				"@ethersproject/wordlists": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/web": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+			"integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/base64": "^5.7.0",
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/strings": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/@ethersproject/wordlists": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+			"integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.7.0",
+				"@ethersproject/hash": "^5.7.0",
+				"@ethersproject/logger": "^5.7.0",
+				"@ethersproject/properties": "^5.7.0",
+				"@ethersproject/strings": "^5.7.0"
+			}
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/aes-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+			"integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+		},
 		"node_modules/@snapshot-labs/snapshot.js/node_modules/ajv": {
-			"version": "8.11.0",
-			"license": "MIT",
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -5938,9 +6577,23 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/bn.js": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+			"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+		},
+		"node_modules/@snapshot-labs/snapshot.js/node_modules/cross-fetch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+			"dependencies": {
+				"node-fetch": "2.6.7"
+			}
+		},
 		"node_modules/@snapshot-labs/snapshot.js/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"node_modules/@sovpro/delimited-stream": {
 			"version": "1.1.0",
@@ -7990,7 +8643,9 @@
 			}
 		},
 		"node_modules/@zero-tech/zdao-sdk": {
-			"version": "0.11.2",
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zdao-sdk/-/zdao-sdk-0.13.2.tgz",
+			"integrity": "sha512-squHEeZoW5L66bTGjCsHz0/sgjNpm+YlISoA8JhNvKYw8zz87FK5ytiodLcTzxn/NYJnYHQdNRGoRpXBBWxZqQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@ethersproject/abstract-signer": "^5.4.1",
@@ -7999,8 +8654,8 @@
 				"@ethersproject/contracts": "^5.4.1",
 				"@ethersproject/providers": "^5.4.5",
 				"@ethersproject/wallet": "^5.4.0",
-				"@gnosis.pm/safe-react-gateway-sdk": "2.10.1",
-				"@snapshot-labs/snapshot.js": "0.3.56",
+				"@safe-global/safe-gateway-typescript-sdk": "3.7.0",
+				"@snapshot-labs/snapshot.js": "0.4.58",
 				"@types/lodash": "4.14.180",
 				"@types/shortid": "0.0.29",
 				"cross-fetch": "3.1.5",
@@ -8696,7 +9351,8 @@
 		},
 		"node_modules/ajv-formats": {
 			"version": "2.1.1",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -8710,8 +9366,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.11.0",
-			"license": "MIT",
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -8725,7 +9382,8 @@
 		},
 		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"node_modules/ajv-keywords": {
 			"version": "3.5.2",
@@ -13051,6 +13709,7 @@
 		},
 		"node_modules/cross-fetch": {
 			"version": "3.0.6",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"node-fetch": "2.6.1"
@@ -13058,6 +13717,7 @@
 		},
 		"node_modules/cross-fetch/node_modules/node-fetch": {
 			"version": "2.6.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "4.x || >=6.0.0"
@@ -17226,7 +17886,9 @@
 		"node_modules/ganache-core": {
 			"version": "2.13.2",
 			"bundleDependencies": [
-				"keccak"
+				"keccak",
+				"node-addon-api",
+				"node-gyp-build"
 			],
 			"license": "MIT",
 			"dependencies": {
@@ -30498,8 +31160,9 @@
 			}
 		},
 		"node_modules/json-to-graphql-query": {
-			"version": "2.2.3",
-			"license": "MIT"
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/json-to-graphql-query/-/json-to-graphql-query-2.2.5.tgz",
+			"integrity": "sha512-5Nom9inkIMrtY992LMBBG1Zaekrc10JaRhyZgprwHBVMDtRgllTvzl0oBbg13wJsVZoSoFNNMaeIVQs0P04vsA=="
 		},
 		"node_modules/json-to-pretty-yaml": {
 			"version": "1.2.2",
@@ -31493,7 +32156,8 @@
 		},
 		"node_modules/lodash.set": {
 			"version": "4.3.2",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
 		},
 		"node_modules/lodash.sortby": {
 			"version": "4.7.0",
@@ -46289,7 +46953,9 @@
 			}
 		},
 		"@ensdomains/eth-ens-namehash": {
-			"version": "2.0.15"
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz",
+			"integrity": "sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw=="
 		},
 		"@eslint/eslintrc": {
 			"version": "0.4.3",
@@ -46663,20 +47329,6 @@
 		},
 		"@gar/promisify": {
 			"version": "1.1.3"
-		},
-		"@gnosis.pm/safe-react-gateway-sdk": {
-			"version": "2.10.1",
-			"requires": {
-				"cross-fetch": "^3.1.5"
-			},
-			"dependencies": {
-				"cross-fetch": {
-					"version": "3.1.5",
-					"requires": {
-						"node-fetch": "2.6.7"
-					}
-				}
-			}
 		},
 		"@graphql-codegen/cli": {
 			"version": "1.21.3",
@@ -48489,6 +49141,24 @@
 				}
 			}
 		},
+		"@safe-global/safe-gateway-typescript-sdk": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.7.0.tgz",
+			"integrity": "sha512-3BvlUgp0oZ1Zkn7nG3wY1jvCEE4t530BjKcaa3r0qsf0whf/ez/0gmQwk7DTOGmVmvOfjj6HHikxnrUCCX+/3Q==",
+			"requires": {
+				"cross-fetch": "^3.1.5"
+			},
+			"dependencies": {
+				"cross-fetch": {
+					"version": "3.1.5",
+					"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+					"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+					"requires": {
+						"node-fetch": "2.6.7"
+					}
+				}
+			}
+		},
 		"@samverschueren/stream-to-observable": {
 			"version": "0.3.1",
 			"requires": {
@@ -48512,24 +49182,382 @@
 			}
 		},
 		"@snapshot-labs/snapshot.js": {
-			"version": "0.3.56",
+			"version": "0.4.58",
+			"resolved": "https://registry.npmjs.org/@snapshot-labs/snapshot.js/-/snapshot.js-0.4.58.tgz",
+			"integrity": "sha512-dtfeiB0kEtpkQXKtc/MXrCj2cy3/CbbtNKMKudm/aLCTyK3DzYtQyvPLxQ1LwEvFcmf+1w3F6LAPENtmuj9obQ==",
 			"requires": {
 				"@ensdomains/eth-ens-namehash": "^2.0.15",
-				"@ethersproject/abi": "^5.0.4",
-				"@ethersproject/bytes": "^5.0.8",
-				"@ethersproject/contracts": "^5.0.3",
-				"@ethersproject/hash": "^5.0.9",
-				"@ethersproject/providers": "^5.3.1",
-				"@ethersproject/wallet": "^5.4.0",
-				"ajv": "^8.6.0",
-				"ajv-formats": "^2.1.0",
-				"cross-fetch": "^3.0.6",
-				"json-to-graphql-query": "^2.0.0",
+				"@ethersproject/abi": "^5.6.4",
+				"@ethersproject/address": "^5.6.1",
+				"@ethersproject/bytes": "^5.6.1",
+				"@ethersproject/contracts": "^5.6.2",
+				"@ethersproject/hash": "^5.6.1",
+				"@ethersproject/providers": "^5.6.8",
+				"@ethersproject/wallet": "^5.6.2",
+				"ajv": "^8.11.0",
+				"ajv-formats": "^2.1.1",
+				"cross-fetch": "^3.1.5",
+				"json-to-graphql-query": "^2.2.4",
 				"lodash.set": "^4.3.2"
 			},
 			"dependencies": {
+				"@ethersproject/abi": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+					"integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+					"requires": {
+						"@ethersproject/address": "^5.7.0",
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/constants": "^5.7.0",
+						"@ethersproject/hash": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/strings": "^5.7.0"
+					}
+				},
+				"@ethersproject/abstract-provider": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+					"integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+					"requires": {
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/networks": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/transactions": "^5.7.0",
+						"@ethersproject/web": "^5.7.0"
+					}
+				},
+				"@ethersproject/abstract-signer": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+					"integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+					"requires": {
+						"@ethersproject/abstract-provider": "^5.7.0",
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0"
+					}
+				},
+				"@ethersproject/address": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+					"integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+					"requires": {
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0"
+					}
+				},
+				"@ethersproject/base64": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+					"integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0"
+					}
+				},
+				"@ethersproject/basex": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+					"integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0"
+					}
+				},
+				"@ethersproject/bignumber": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+					"integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"bn.js": "^5.2.1"
+					}
+				},
+				"@ethersproject/bytes": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+					"integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+					"requires": {
+						"@ethersproject/logger": "^5.7.0"
+					}
+				},
+				"@ethersproject/constants": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+					"integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+					"requires": {
+						"@ethersproject/bignumber": "^5.7.0"
+					}
+				},
+				"@ethersproject/contracts": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+					"integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+					"requires": {
+						"@ethersproject/abi": "^5.7.0",
+						"@ethersproject/abstract-provider": "^5.7.0",
+						"@ethersproject/abstract-signer": "^5.7.0",
+						"@ethersproject/address": "^5.7.0",
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/constants": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/transactions": "^5.7.0"
+					}
+				},
+				"@ethersproject/hash": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+					"integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+					"requires": {
+						"@ethersproject/abstract-signer": "^5.7.0",
+						"@ethersproject/address": "^5.7.0",
+						"@ethersproject/base64": "^5.7.0",
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/strings": "^5.7.0"
+					}
+				},
+				"@ethersproject/hdnode": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+					"integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+					"requires": {
+						"@ethersproject/abstract-signer": "^5.7.0",
+						"@ethersproject/basex": "^5.7.0",
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/pbkdf2": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/sha2": "^5.7.0",
+						"@ethersproject/signing-key": "^5.7.0",
+						"@ethersproject/strings": "^5.7.0",
+						"@ethersproject/transactions": "^5.7.0",
+						"@ethersproject/wordlists": "^5.7.0"
+					}
+				},
+				"@ethersproject/json-wallets": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+					"integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+					"requires": {
+						"@ethersproject/abstract-signer": "^5.7.0",
+						"@ethersproject/address": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/hdnode": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/pbkdf2": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/random": "^5.7.0",
+						"@ethersproject/strings": "^5.7.0",
+						"@ethersproject/transactions": "^5.7.0",
+						"aes-js": "3.0.0",
+						"scrypt-js": "3.0.1"
+					}
+				},
+				"@ethersproject/keccak256": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+					"integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"js-sha3": "0.8.0"
+					}
+				},
+				"@ethersproject/logger": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+					"integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
+				},
+				"@ethersproject/networks": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+					"integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+					"requires": {
+						"@ethersproject/logger": "^5.7.0"
+					}
+				},
+				"@ethersproject/pbkdf2": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+					"integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/sha2": "^5.7.0"
+					}
+				},
+				"@ethersproject/properties": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+					"integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+					"requires": {
+						"@ethersproject/logger": "^5.7.0"
+					}
+				},
+				"@ethersproject/providers": {
+					"version": "5.7.2",
+					"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+					"integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+					"requires": {
+						"@ethersproject/abstract-provider": "^5.7.0",
+						"@ethersproject/abstract-signer": "^5.7.0",
+						"@ethersproject/address": "^5.7.0",
+						"@ethersproject/base64": "^5.7.0",
+						"@ethersproject/basex": "^5.7.0",
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/constants": "^5.7.0",
+						"@ethersproject/hash": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/networks": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/random": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0",
+						"@ethersproject/sha2": "^5.7.0",
+						"@ethersproject/strings": "^5.7.0",
+						"@ethersproject/transactions": "^5.7.0",
+						"@ethersproject/web": "^5.7.0",
+						"bech32": "1.1.4",
+						"ws": "7.4.6"
+					}
+				},
+				"@ethersproject/random": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+					"integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0"
+					}
+				},
+				"@ethersproject/rlp": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+					"integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0"
+					}
+				},
+				"@ethersproject/sha2": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+					"integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"hash.js": "1.1.7"
+					}
+				},
+				"@ethersproject/signing-key": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+					"integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"bn.js": "^5.2.1",
+						"elliptic": "6.5.4",
+						"hash.js": "1.1.7"
+					}
+				},
+				"@ethersproject/strings": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+					"integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/constants": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0"
+					}
+				},
+				"@ethersproject/transactions": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+					"integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+					"requires": {
+						"@ethersproject/address": "^5.7.0",
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/constants": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/rlp": "^5.7.0",
+						"@ethersproject/signing-key": "^5.7.0"
+					}
+				},
+				"@ethersproject/wallet": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+					"integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+					"requires": {
+						"@ethersproject/abstract-provider": "^5.7.0",
+						"@ethersproject/abstract-signer": "^5.7.0",
+						"@ethersproject/address": "^5.7.0",
+						"@ethersproject/bignumber": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/hash": "^5.7.0",
+						"@ethersproject/hdnode": "^5.7.0",
+						"@ethersproject/json-wallets": "^5.7.0",
+						"@ethersproject/keccak256": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/random": "^5.7.0",
+						"@ethersproject/signing-key": "^5.7.0",
+						"@ethersproject/transactions": "^5.7.0",
+						"@ethersproject/wordlists": "^5.7.0"
+					}
+				},
+				"@ethersproject/web": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+					"integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+					"requires": {
+						"@ethersproject/base64": "^5.7.0",
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/strings": "^5.7.0"
+					}
+				},
+				"@ethersproject/wordlists": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+					"integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+					"requires": {
+						"@ethersproject/bytes": "^5.7.0",
+						"@ethersproject/hash": "^5.7.0",
+						"@ethersproject/logger": "^5.7.0",
+						"@ethersproject/properties": "^5.7.0",
+						"@ethersproject/strings": "^5.7.0"
+					}
+				},
+				"aes-js": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+					"integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+				},
 				"ajv": {
-					"version": "8.11.0",
+					"version": "8.12.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+					"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"json-schema-traverse": "^1.0.0",
@@ -48537,8 +49565,23 @@
 						"uri-js": "^4.2.2"
 					}
 				},
+				"bn.js": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+					"integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+				},
+				"cross-fetch": {
+					"version": "3.1.5",
+					"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+					"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+					"requires": {
+						"node-fetch": "2.6.7"
+					}
+				},
 				"json-schema-traverse": {
-					"version": "1.0.0"
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 				}
 			}
 		},
@@ -49993,7 +51036,9 @@
 			}
 		},
 		"@zero-tech/zdao-sdk": {
-			"version": "0.11.2",
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zdao-sdk/-/zdao-sdk-0.13.2.tgz",
+			"integrity": "sha512-squHEeZoW5L66bTGjCsHz0/sgjNpm+YlISoA8JhNvKYw8zz87FK5ytiodLcTzxn/NYJnYHQdNRGoRpXBBWxZqQ==",
 			"requires": {
 				"@ethersproject/abstract-signer": "^5.4.1",
 				"@ethersproject/address": "^5.4.0",
@@ -50001,8 +51046,8 @@
 				"@ethersproject/contracts": "^5.4.1",
 				"@ethersproject/providers": "^5.4.5",
 				"@ethersproject/wallet": "^5.4.0",
-				"@gnosis.pm/safe-react-gateway-sdk": "2.10.1",
-				"@snapshot-labs/snapshot.js": "0.3.56",
+				"@safe-global/safe-gateway-typescript-sdk": "3.7.0",
+				"@snapshot-labs/snapshot.js": "0.4.58",
 				"@types/lodash": "4.14.180",
 				"@types/shortid": "0.0.29",
 				"cross-fetch": "3.1.5",
@@ -50420,12 +51465,16 @@
 		},
 		"ajv-formats": {
 			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"requires": {
 				"ajv": "^8.0.0"
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.11.0",
+					"version": "8.12.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+					"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"json-schema-traverse": "^1.0.0",
@@ -50434,7 +51483,9 @@
 					}
 				},
 				"json-schema-traverse": {
-					"version": "1.0.0"
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 				}
 			}
 		},
@@ -53513,12 +54564,14 @@
 		},
 		"cross-fetch": {
 			"version": "3.0.6",
+			"dev": true,
 			"requires": {
 				"node-fetch": "2.6.1"
 			},
 			"dependencies": {
 				"node-fetch": {
-					"version": "2.6.1"
+					"version": "2.6.1",
+					"dev": true
 				}
 			}
 		},
@@ -65689,7 +66742,9 @@
 			}
 		},
 		"json-to-graphql-query": {
-			"version": "2.2.3"
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/json-to-graphql-query/-/json-to-graphql-query-2.2.5.tgz",
+			"integrity": "sha512-5Nom9inkIMrtY992LMBBG1Zaekrc10JaRhyZgprwHBVMDtRgllTvzl0oBbg13wJsVZoSoFNNMaeIVQs0P04vsA=="
 		},
 		"json-to-pretty-yaml": {
 			"version": "1.2.2",
@@ -66351,7 +67406,9 @@
 			"version": "4.6.0"
 		},
 		"lodash.set": {
-			"version": "4.3.2"
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "zns-dapp",
-	"version": "0.18.8",
+	"version": "0.18.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "zns-dapp",
-			"version": "0.18.8",
+			"version": "0.18.9",
 			"dependencies": {
 				"@apollo/client": "^3.3.13",
 				"@ethersproject/abi": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@web3-react/walletconnect-connector": "6.2.4",
 		"@web3-react/walletlink-connector": "^6.1.9",
 		"@zero-tech/zauction-sdk": "0.2.12",
-		"@zero-tech/zdao-sdk": "0.11.2",
+		"@zero-tech/zdao-sdk": "0.13.2",
 		"@zero-tech/zero-contracts": "^0.0.7",
 		"@zero-tech/zfi-sdk": "0.2.2",
 		"@zero-tech/zns-sdk": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zns-dapp",
-	"version": "0.18.8",
+	"version": "0.18.9",
 	"private": true,
 	"dependencies": {
 		"@apollo/client": "^3.3.13",


### PR DESCRIPTION
 - Build related changes
 - Bug fix


## 3. What is the old behaviour?
DAO proposal data error - empty.
Outdated zdao-sdk version (0.11.2) - cause of the above


## 4. What is the new behaviour?
DAO proposal data successful.
Updated zdao-sdk version (0.13.2) - fix for the above

<img width="990" alt="Screenshot 2023-02-07 at 18 15 08" src="https://user-images.githubusercontent.com/39112648/217330911-884cfb09-c0a2-4b97-b3e6-c96d4f1a3560.png">

Ignore icon - server not running in this screenshot

