### PR TITLE
fix: pool link redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,9 @@ function App() {
 							<Route path={ROUTES.STAKING} component={Staking} />
 							<Route path={ROUTES.ZDAO} component={DAO} />
 							<Route path={ROUTES.PROFILE} component={Profile} />
+							<Route exact path="/wilder/staking/pools">
+								<Redirect to={ROUTES.STAKING} />
+							</Route>
 							<Route exact path="/">
 								<Redirect to="/market" />
 							</Route>


### PR DESCRIPTION
Fixes the pool redirect in `zApp-Staking`. It would be good to fix this in `zApp-Staking`, however, we want to keep scope as small as possible as this app will be deprecated in the not-so-distant future.