### PR TITLE
chore: bump zapp-daos (`0.18.1` -> `0.18.2`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "zns-dapp",
-	"version": "0.23.0",
+	"version": "0.23.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "zns-dapp",
-			"version": "0.23.0",
+			"version": "0.23.1",
 			"dependencies": {
 				"@coinbase/wallet-sdk": "^3.7.1",
 				"@ethersproject/abi": "^5.1.0",
@@ -23,7 +23,7 @@
 				"@web3-react/types": "^8.2.0",
 				"@web3-react/walletconnect-v2": "^8.3.7",
 				"@web3modal/wagmi": "^3.1.0",
-				"@zero-tech/zapp-daos": "^0.18.1",
+				"@zero-tech/zapp-daos": "^0.18.2",
 				"@zero-tech/zapp-staking": "^0.9.0",
 				"@zero-tech/zauction-sdk": "0.2.12",
 				"@zero-tech/zdao-sdk": "0.14.1",
@@ -6883,6 +6883,17 @@
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"peer": true
 		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
 		"node_modules/@sinonjs/commons": {
 			"version": "1.8.3",
 			"license": "BSD-3-Clause",
@@ -7307,6 +7318,93 @@
 				"css-loader": "*",
 				"sass-loader": "*",
 				"style-loader": "*"
+			}
+		},
+		"node_modules/@supabase/functions-js": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+			"integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/gotrue-js": {
+			"version": "2.60.1",
+			"resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.60.1.tgz",
+			"integrity": "sha512-dM28NhyPS5NLWpJbVokxGbuEMmMK2K+EBXYlNU2NEYzp1BrkdxetNh8ucslMbKauJ93XAEhbMCQHSO9fZ2E+DQ==",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/node-fetch": {
+			"version": "2.6.15",
+			"resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+			"integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			}
+		},
+		"node_modules/@supabase/postgrest-js": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.0.tgz",
+			"integrity": "sha512-axP6cU69jDrLbfihJKQ6vU27tklD0gzb9idkMN363MtTXeJVt5DQNT3JnJ58JVNBdL74hgm26rAsFNvHk+tnSw==",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/realtime-js": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.0.tgz",
+			"integrity": "sha512-e/SI+/eqFJorAKAgVAwKQ9hSDQSBp86Yh7XbQmfJJ90LEfpM52HlTfJt/03lcepRu6BmH5h1uYn1b4zta7ghdw==",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14",
+				"@types/phoenix": "^1.5.4",
+				"@types/websocket": "^1.0.3",
+				"ws": "^8.14.2"
+			}
+		},
+		"node_modules/@supabase/realtime-js/node_modules/ws": {
+			"version": "8.14.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+			"integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@supabase/storage-js": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+			"integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/supabase-js": {
+			"version": "2.39.0",
+			"resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.39.0.tgz",
+			"integrity": "sha512-cYfnwWRW5rYBbPT/BNIejtRT9ULdD9PnIExQV28PZpqcqm3PLwS4f3pY7WGB01Da63VYdvktZPKuYvreqsj/Zg==",
+			"dependencies": {
+				"@supabase/functions-js": "^2.1.5",
+				"@supabase/gotrue-js": "^2.56.0",
+				"@supabase/node-fetch": "^2.6.14",
+				"@supabase/postgrest-js": "^1.8.6",
+				"@supabase/realtime-js": "^2.8.4",
+				"@supabase/storage-js": "^2.5.4"
 			}
 		},
 		"node_modules/@swc/helpers": {
@@ -7819,6 +7917,11 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/phoenix": {
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.4.tgz",
+			"integrity": "sha512-B34A7uot1Cv0XtaHRYDATltAdKx0BvVKNgYNqE4WjtPUa4VQJM7kxeXcVKaH+KS+kCmZ+6w+QaUdcljiheiBJA=="
+		},
 		"node_modules/@types/prettier": {
 			"version": "2.4.4",
 			"dev": true,
@@ -7960,6 +8063,14 @@
 		"node_modules/@types/unist": {
 			"version": "2.0.6",
 			"license": "MIT"
+		},
+		"node_modules/@types/websocket": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.10.tgz",
+			"integrity": "sha512-svjGZvPB7EzuYS94cI7a+qhwgGU1y89wUgjT6E2wVUfmAGIvRfT7obBvRtnhXCSsoMdlG4gBFGE7MfkIXZLoww==",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/ws": {
 			"version": "7.4.7",
@@ -9924,15 +10035,16 @@
 			}
 		},
 		"node_modules/@zero-tech/zapp-daos": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zapp-daos/-/zapp-daos-0.18.1.tgz",
-			"integrity": "sha512-Q1KBR+ZWffjC0H9WlEDomSmX5J+t94I0pU1nXtkOGLhUwICB7GXJUARD1OZYNgtIeq3iSR23FR65lm1zSt0Vdw==",
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zapp-daos/-/zapp-daos-0.18.2.tgz",
+			"integrity": "sha512-OyClBc9iQJIXvW5qE5ZR/bTwx2rFvzOPo5H+Ims0hztPhJLsIMEV6lQk7/yXCPlQLHPxzGHwlvouf8Ympr5jZA==",
 			"dependencies": {
 				"@babel/plugin-proposal-class-properties": "^7.18.6",
 				"@ethersproject/units": "^5.6.1",
 				"@hookform/resolvers": "^3.3.1",
 				"@safe-global/api-kit": "^1.3.1",
 				"@safe-global/protocol-kit": "^1.3.0",
+				"@supabase/supabase-js": "^2.39.0",
 				"@web3modal/wagmi": "^3.0.0-beta.4",
 				"@zero-tech/zapp-utils": "^0.6.7",
 				"@zero-tech/zdao-sdk": "0.16.1",
@@ -9950,6 +10062,7 @@
 				"react-query": "^3.39.1",
 				"react-resize-detector": "7.0.0",
 				"react-router-dom": "^5.3.0 || ^6.0.0",
+				"remark-emoji": "^4.0.0",
 				"viem": "^1.6.4",
 				"wagmi": "^1.3.10",
 				"yup": "^0.32.11",
@@ -10061,6 +10174,19 @@
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/@types/mdast": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+			"integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/@types/unist": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+			"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
 		},
 		"node_modules/@zero-tech/zapp-daos/node_modules/@zero-tech/zdao-sdk": {
 			"version": "0.16.1",
@@ -10238,6 +10364,72 @@
 				"react-dom": ">=16.8.0"
 			}
 		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/@zero-tech/zui/node_modules/@types/mdast": {
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+			"integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+			"dependencies": {
+				"@types/unist": "^2"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/@zero-tech/zui/node_modules/@types/unist": {
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+			"integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/@zero-tech/zui/node_modules/mdast-util-find-and-replace": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+			"integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+			"dependencies": {
+				"@types/mdast": "^3.0.0",
+				"escape-string-regexp": "^5.0.0",
+				"unist-util-is": "^5.0.0",
+				"unist-util-visit-parents": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/@zero-tech/zui/node_modules/remark-emoji": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-3.1.2.tgz",
+			"integrity": "sha512-QwhAzNk27Ol64uV4z/3n55MKrNz9bhr8wg+mO5aGqIYDS+jUarS1d8Y0ZIeEBVhfGkXj6gGYM+727sOgAPvV/A==",
+			"dependencies": {
+				"emoticon": "^4.0.1",
+				"mdast-util-find-and-replace": "^2.2.2",
+				"node-emoji": "^1.11.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/@zero-tech/zui/node_modules/unist-util-is": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+			"integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/@zero-tech/zui/node_modules/unist-util-visit-parents": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+			"integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-is": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/@zero-tech/zapp-daos/node_modules/cross-fetch": {
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -10303,6 +10495,21 @@
 				"graphql": "14 - 16"
 			}
 		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/mdast-util-find-and-replace": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
+			"integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"escape-string-regexp": "^5.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/@zero-tech/zapp-daos/node_modules/react-hook-form": {
 			"version": "7.47.0",
 			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
@@ -10348,6 +10555,35 @@
 				"react-dom": ">=16.8"
 			}
 		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/remark-emoji": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-4.0.1.tgz",
+			"integrity": "sha512-fHdvsTR1dHkWKev9eNyhTo4EFwbUvJ8ka9SgeWkMPYFX4WoI7ViVBms3PjlQYgw5TLvNQso3GUB/b/8t3yo+dg==",
+			"dependencies": {
+				"@types/mdast": "^4.0.2",
+				"emoticon": "^4.0.1",
+				"mdast-util-find-and-replace": "^3.0.1",
+				"node-emoji": "^2.1.0",
+				"unified": "^11.0.4"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/remark-emoji/node_modules/node-emoji": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
+			"integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
+			"dependencies": {
+				"@sindresorhus/is": "^4.6.0",
+				"char-regex": "^1.0.2",
+				"emojilib": "^2.4.0",
+				"skin-tone": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@zero-tech/zapp-daos/node_modules/typescript": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
@@ -10358,6 +10594,88 @@
 			},
 			"engines": {
 				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/unified": {
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+			"integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"bail": "^2.0.0",
+				"devlop": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/unist-util-is": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+			"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/unist-util-visit-parents": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+			"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/vfile": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+			"integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/@zero-tech/zapp-daos/node_modules/vfile-message": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+			"integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/@zero-tech/zapp-staking": {
@@ -12814,6 +13132,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/character-entities": {
 			"version": "2.0.1",
 			"license": "MIT",
@@ -13982,6 +14308,18 @@
 			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
 			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
 		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/diff-sequences": {
 			"version": "26.6.2",
 			"dev": true,
@@ -14109,6 +14447,11 @@
 		"node_modules/emailjs-com": {
 			"version": "2.6.4",
 			"license": "MIT"
+		},
+		"node_modules/emojilib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+			"integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
 		},
 		"node_modules/emojis-list": {
 			"version": "3.0.0",
@@ -14400,6 +14743,17 @@
 		"node_modules/escape-html": {
 			"version": "1.0.3",
 			"license": "MIT"
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/esprima": {
 			"version": "4.0.1",
@@ -16763,6 +17117,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-plain-object": {
 			"version": "2.0.4",
 			"license": "MIT",
@@ -17925,16 +18290,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
@@ -23599,6 +23954,17 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/skin-tone": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+			"integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+			"dependencies": {
+				"unicode-emoji-modifier-base": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"license": "MIT",
@@ -24426,17 +24792,6 @@
 				"xhr-request": "^1.0.1"
 			}
 		},
-		"node_modules/swarm-js/node_modules/@sindresorhus/is": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
 		"node_modules/swarm-js/node_modules/@szmarczak/http-timer": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -25250,6 +25605,14 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/unicode-emoji-modifier-base": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+			"integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/unicode-match-property-ecmascript": {
 			"version": "2.0.0",
 			"license": "MIT",
@@ -25293,16 +25656,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unified/node_modules/is-plain-obj": {
-			"version": "4.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/union-value": {
@@ -26447,17 +26800,6 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/web3-bzz/node_modules/@sindresorhus/is": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/is?sponsor=1"
 			}
 		},
 		"node_modules/web3-bzz/node_modules/@szmarczak/http-timer": {
@@ -32678,6 +33020,11 @@
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"peer": true
 		},
+		"@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
+		},
 		"@sinonjs/commons": {
 			"version": "1.8.3",
 			"requires": {
@@ -33005,6 +33352,78 @@
 			"resolved": "https://registry.npmjs.org/@storybook/preset-scss/-/preset-scss-1.0.3.tgz",
 			"integrity": "sha512-o9Iz6wxPeNENrQa2mKlsDKynBfqU2uWaRP80HeWp4TkGgf7/x3DVF2O7yi9N0x/PI1qzzTTpxlQ90D62XmpiTw==",
 			"requires": {}
+		},
+		"@supabase/functions-js": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+			"integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+			"requires": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"@supabase/gotrue-js": {
+			"version": "2.60.1",
+			"resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.60.1.tgz",
+			"integrity": "sha512-dM28NhyPS5NLWpJbVokxGbuEMmMK2K+EBXYlNU2NEYzp1BrkdxetNh8ucslMbKauJ93XAEhbMCQHSO9fZ2E+DQ==",
+			"requires": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"@supabase/node-fetch": {
+			"version": "2.6.15",
+			"resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+			"integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			}
+		},
+		"@supabase/postgrest-js": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.0.tgz",
+			"integrity": "sha512-axP6cU69jDrLbfihJKQ6vU27tklD0gzb9idkMN363MtTXeJVt5DQNT3JnJ58JVNBdL74hgm26rAsFNvHk+tnSw==",
+			"requires": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"@supabase/realtime-js": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.0.tgz",
+			"integrity": "sha512-e/SI+/eqFJorAKAgVAwKQ9hSDQSBp86Yh7XbQmfJJ90LEfpM52HlTfJt/03lcepRu6BmH5h1uYn1b4zta7ghdw==",
+			"requires": {
+				"@supabase/node-fetch": "^2.6.14",
+				"@types/phoenix": "^1.5.4",
+				"@types/websocket": "^1.0.3",
+				"ws": "^8.14.2"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "8.14.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+					"integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+					"requires": {}
+				}
+			}
+		},
+		"@supabase/storage-js": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+			"integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+			"requires": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"@supabase/supabase-js": {
+			"version": "2.39.0",
+			"resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.39.0.tgz",
+			"integrity": "sha512-cYfnwWRW5rYBbPT/BNIejtRT9ULdD9PnIExQV28PZpqcqm3PLwS4f3pY7WGB01Da63VYdvktZPKuYvreqsj/Zg==",
+			"requires": {
+				"@supabase/functions-js": "^2.1.5",
+				"@supabase/gotrue-js": "^2.56.0",
+				"@supabase/node-fetch": "^2.6.14",
+				"@supabase/postgrest-js": "^1.8.6",
+				"@supabase/realtime-js": "^2.8.4",
+				"@supabase/storage-js": "^2.5.4"
+			}
 		},
 		"@swc/helpers": {
 			"version": "0.5.1",
@@ -33378,6 +33797,11 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/phoenix": {
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.4.tgz",
+			"integrity": "sha512-B34A7uot1Cv0XtaHRYDATltAdKx0BvVKNgYNqE4WjtPUa4VQJM7kxeXcVKaH+KS+kCmZ+6w+QaUdcljiheiBJA=="
+		},
 		"@types/prettier": {
 			"version": "2.4.4",
 			"dev": true
@@ -33502,6 +33926,14 @@
 		},
 		"@types/unist": {
 			"version": "2.0.6"
+		},
+		"@types/websocket": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.10.tgz",
+			"integrity": "sha512-svjGZvPB7EzuYS94cI7a+qhwgGU1y89wUgjT6E2wVUfmAGIvRfT7obBvRtnhXCSsoMdlG4gBFGE7MfkIXZLoww==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/ws": {
 			"version": "7.4.7",
@@ -35190,15 +35622,16 @@
 			}
 		},
 		"@zero-tech/zapp-daos": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zapp-daos/-/zapp-daos-0.18.1.tgz",
-			"integrity": "sha512-Q1KBR+ZWffjC0H9WlEDomSmX5J+t94I0pU1nXtkOGLhUwICB7GXJUARD1OZYNgtIeq3iSR23FR65lm1zSt0Vdw==",
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zapp-daos/-/zapp-daos-0.18.2.tgz",
+			"integrity": "sha512-OyClBc9iQJIXvW5qE5ZR/bTwx2rFvzOPo5H+Ims0hztPhJLsIMEV6lQk7/yXCPlQLHPxzGHwlvouf8Ympr5jZA==",
 			"requires": {
 				"@babel/plugin-proposal-class-properties": "^7.18.6",
 				"@ethersproject/units": "^5.6.1",
 				"@hookform/resolvers": "^3.3.1",
 				"@safe-global/api-kit": "^1.3.1",
 				"@safe-global/protocol-kit": "^1.3.0",
+				"@supabase/supabase-js": "^2.39.0",
 				"@web3modal/wagmi": "^3.0.0-beta.4",
 				"@zero-tech/zapp-utils": "^0.6.7",
 				"@zero-tech/zdao-sdk": "0.16.1",
@@ -35216,6 +35649,7 @@
 				"react-query": "^3.39.1",
 				"react-resize-detector": "7.0.0",
 				"react-router-dom": "^5.3.0 || ^6.0.0",
+				"remark-emoji": "^4.0.0",
 				"viem": "^1.6.4",
 				"wagmi": "^1.3.10",
 				"yup": "^0.32.11",
@@ -35283,6 +35717,19 @@
 					"version": "1.9.0",
 					"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0.tgz",
 					"integrity": "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA=="
+				},
+				"@types/mdast": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
+					"integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+					"requires": {
+						"@types/unist": "*"
+					}
+				},
+				"@types/unist": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+					"integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
 				},
 				"@zero-tech/zdao-sdk": {
 					"version": "0.16.1",
@@ -35420,6 +35867,59 @@
 						"remark-emoji": "^3.0.2",
 						"remark-gemoji": "^7.0.1",
 						"sass": "^1.52.2"
+					},
+					"dependencies": {
+						"@types/mdast": {
+							"version": "3.0.15",
+							"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+							"integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+							"requires": {
+								"@types/unist": "^2"
+							}
+						},
+						"@types/unist": {
+							"version": "2.0.10",
+							"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+							"integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+						},
+						"mdast-util-find-and-replace": {
+							"version": "2.2.2",
+							"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+							"integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+							"requires": {
+								"@types/mdast": "^3.0.0",
+								"escape-string-regexp": "^5.0.0",
+								"unist-util-is": "^5.0.0",
+								"unist-util-visit-parents": "^5.0.0"
+							}
+						},
+						"remark-emoji": {
+							"version": "3.1.2",
+							"resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-3.1.2.tgz",
+							"integrity": "sha512-QwhAzNk27Ol64uV4z/3n55MKrNz9bhr8wg+mO5aGqIYDS+jUarS1d8Y0ZIeEBVhfGkXj6gGYM+727sOgAPvV/A==",
+							"requires": {
+								"emoticon": "^4.0.1",
+								"mdast-util-find-and-replace": "^2.2.2",
+								"node-emoji": "^1.11.0"
+							}
+						},
+						"unist-util-is": {
+							"version": "5.2.1",
+							"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+							"integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+							"requires": {
+								"@types/unist": "^2.0.0"
+							}
+						},
+						"unist-util-visit-parents": {
+							"version": "5.1.3",
+							"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+							"integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+							"requires": {
+								"@types/unist": "^2.0.0",
+								"unist-util-is": "^5.0.0"
+							}
+						}
 					}
 				},
 				"cross-fetch": {
@@ -35468,6 +35968,17 @@
 						"form-data": "^3.0.0"
 					}
 				},
+				"mdast-util-find-and-replace": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
+					"integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+					"requires": {
+						"@types/mdast": "^4.0.0",
+						"escape-string-regexp": "^5.0.0",
+						"unist-util-is": "^6.0.0",
+						"unist-util-visit-parents": "^6.0.0"
+					}
+				},
 				"react-hook-form": {
 					"version": "7.47.0",
 					"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
@@ -35491,10 +36002,93 @@
 						"react-router": "6.16.0"
 					}
 				},
+				"remark-emoji": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-4.0.1.tgz",
+					"integrity": "sha512-fHdvsTR1dHkWKev9eNyhTo4EFwbUvJ8ka9SgeWkMPYFX4WoI7ViVBms3PjlQYgw5TLvNQso3GUB/b/8t3yo+dg==",
+					"requires": {
+						"@types/mdast": "^4.0.2",
+						"emoticon": "^4.0.1",
+						"mdast-util-find-and-replace": "^3.0.1",
+						"node-emoji": "^2.1.0",
+						"unified": "^11.0.4"
+					},
+					"dependencies": {
+						"node-emoji": {
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
+							"integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
+							"requires": {
+								"@sindresorhus/is": "^4.6.0",
+								"char-regex": "^1.0.2",
+								"emojilib": "^2.4.0",
+								"skin-tone": "^2.0.0"
+							}
+						}
+					}
+				},
 				"typescript": {
 					"version": "4.6.2",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
 					"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
+				},
+				"unified": {
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.4.tgz",
+					"integrity": "sha512-apMPnyLjAX+ty4OrNap7yumyVAMlKx5IWU2wlzzUdYJO9A8f1p9m/gywF/GM2ZDFcjQPrx59Mc90KwmxsoklxQ==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"bail": "^2.0.0",
+						"devlop": "^1.0.0",
+						"extend": "^3.0.0",
+						"is-plain-obj": "^4.0.0",
+						"trough": "^2.0.0",
+						"vfile": "^6.0.0"
+					}
+				},
+				"unist-util-is": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+					"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-stringify-position": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+					"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+					"requires": {
+						"@types/unist": "^3.0.0"
+					}
+				},
+				"unist-util-visit-parents": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+					"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-is": "^6.0.0"
+					}
+				},
+				"vfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.1.tgz",
+					"integrity": "sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-stringify-position": "^4.0.0",
+						"vfile-message": "^4.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+					"integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+					"requires": {
+						"@types/unist": "^3.0.0",
+						"unist-util-stringify-position": "^4.0.0"
+					}
 				}
 			}
 		},
@@ -37161,6 +37755,11 @@
 				}
 			}
 		},
+		"char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
+		},
 		"character-entities": {
 			"version": "2.0.1"
 		},
@@ -37991,6 +38590,14 @@
 			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
 			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
 		},
+		"devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"requires": {
+				"dequal": "^2.0.0"
+			}
+		},
 		"diff-sequences": {
 			"version": "26.6.2",
 			"dev": true
@@ -38091,6 +38698,11 @@
 		},
 		"emailjs-com": {
 			"version": "2.6.4"
+		},
+		"emojilib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+			"integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
 		},
 		"emojis-list": {
 			"version": "3.0.0",
@@ -38313,6 +38925,11 @@
 		},
 		"escape-html": {
 			"version": "1.0.3"
+		},
+		"escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
 		},
 		"esprima": {
 			"version": "4.0.1",
@@ -39927,6 +40544,11 @@
 			"version": "1.0.1",
 			"dev": true
 		},
+		"is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"peer": true,
@@ -40733,11 +41355,6 @@
 				"escape-string-regexp": "^5.0.0",
 				"unist-util-is": "^5.0.0",
 				"unist-util-visit-parents": "^4.0.0"
-			},
-			"dependencies": {
-				"escape-string-regexp": {
-					"version": "5.0.0"
-				}
 			}
 		},
 		"mdast-util-from-markdown": {
@@ -44713,6 +45330,14 @@
 			"version": "1.0.5",
 			"peer": true
 		},
+		"skin-tone": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+			"integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+			"requires": {
+				"unicode-emoji-modifier-base": "^1.0.0"
+			}
+		},
 		"slash": {
 			"version": "3.0.0"
 		},
@@ -45307,11 +45932,6 @@
 				"xhr-request": "^1.0.1"
 			},
 			"dependencies": {
-				"@sindresorhus/is": {
-					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-					"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
-				},
 				"@szmarczak/http-timer": {
 					"version": "4.0.6",
 					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -45899,6 +46519,11 @@
 			"version": "2.0.0",
 			"peer": true
 		},
+		"unicode-emoji-modifier-base": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+			"integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="
+		},
 		"unicode-match-property-ecmascript": {
 			"version": "2.0.0",
 			"peer": true,
@@ -45925,11 +46550,6 @@
 				"is-plain-obj": "^4.0.0",
 				"trough": "^2.0.0",
 				"vfile": "^5.0.0"
-			},
-			"dependencies": {
-				"is-plain-obj": {
-					"version": "4.0.0"
-				}
 			}
 		},
 		"union-value": {
@@ -46659,11 +47279,6 @@
 				"swarm-js": "^0.1.40"
 			},
 			"dependencies": {
-				"@sindresorhus/is": {
-					"version": "4.6.0",
-					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-					"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
-				},
 				"@szmarczak/http-timer": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@web3-react/types": "^8.2.0",
 		"@web3-react/walletconnect-v2": "^8.3.7",
 		"@web3modal/wagmi": "^3.1.0",
-		"@zero-tech/zapp-daos": "^0.18.1",
+		"@zero-tech/zapp-daos": "^0.18.2",
 		"@zero-tech/zapp-staking": "^0.9.0",
 		"@zero-tech/zauction-sdk": "0.2.12",
 		"@zero-tech/zdao-sdk": "0.14.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
 			'react-dom': resolve('node_modules/react-dom'),
 			'react-router': resolve('node_modules/react-router'),
 			'react-router-dom': resolve('node_modules/react-router-dom'),
+			'remark-emoji': resolve('node_modules/remark-emoji'),
 		},
 	},
 	css: {


### PR DESCRIPTION
- Fixes asset price loading